### PR TITLE
Node refresh bug on hash routing

### DIFF
--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -98,6 +98,8 @@ export const buildFromRelativePath = node => {
   return GenericHelpers.addLeadingSlash(concatenatePath(windowPath, node.link));
 };
 
+export const getHashPath = (url = window.location.hash) => url.split('#/')[1];
+
 export const getModifiedPathname = () => {
   if (!window.history.state) {
     return '';

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -87,7 +87,20 @@ export const getContentViewParamPrefix = () => {
 };
 
 export const addRouteChangeListener = callback => {
-  if (LuigiConfig.getConfigValue('routing.useHashRouting')) {
+  const hashRoutingActive = LuigiConfig.getConfigValue(
+    'routing.useHashRouting'
+  );
+
+  window.addEventListener('message', e => {
+    const path = hashRoutingActive
+      ? window.location.hash.split('#/')[1]
+      : Routing.getModifiedPathname();
+    if ('refreshRoute' === e.data.msg && e.origin === window.origin) {
+      callback(path);
+    }
+  });
+
+  if (hashRoutingActive) {
     const getModifiedHash = s => s.newURL.split('#/')[1];
     return window.addEventListener('hashchange', event => {
       callback(getModifiedHash(event));
@@ -96,12 +109,6 @@ export const addRouteChangeListener = callback => {
 
   window.addEventListener('popstate', () => {
     callback(Routing.getModifiedPathname());
-  });
-
-  window.addEventListener('message', e => {
-    if ('refreshRoute' === e.data.msg && e.origin === window.origin) {
-      callback(Routing.getModifiedPathname());
-    }
   });
 };
 

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -101,9 +101,8 @@ export const addRouteChangeListener = callback => {
   });
 
   if (hashRoutingActive) {
-    const getModifiedHash = s => Routing.getHashPath(s.newURL);
     return window.addEventListener('hashchange', event => {
-      callback(getModifiedHash(event));
+      callback(Routing.getHashPath(event.newURL));
     });
   }
 

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -93,7 +93,7 @@ export const addRouteChangeListener = callback => {
 
   window.addEventListener('message', e => {
     const path = hashRoutingActive
-      ? window.location.hash.split('#/')[1]
+      ? Routing.getHashPath()
       : Routing.getModifiedPathname();
     if ('refreshRoute' === e.data.msg && e.origin === window.origin) {
       callback(path);
@@ -101,7 +101,7 @@ export const addRouteChangeListener = callback => {
   });
 
   if (hashRoutingActive) {
-    const getModifiedHash = s => s.newURL.split('#/')[1];
+    const getModifiedHash = s => Routing.getHashPath(s.newURL);
     return window.addEventListener('hashchange', event => {
       callback(getModifiedHash(event));
     });

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -92,10 +92,10 @@ export const addRouteChangeListener = callback => {
   );
 
   window.addEventListener('message', e => {
-    const path = hashRoutingActive
-      ? Routing.getHashPath()
-      : Routing.getModifiedPathname();
     if ('refreshRoute' === e.data.msg && e.origin === window.origin) {
+      const path = hashRoutingActive
+        ? Routing.getHashPath()
+        : Routing.getModifiedPathname();
       callback(path);
     }
   });

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -28,6 +28,20 @@ describe('Routing', () => {
     sinon.restore();
   });
 
+  describe('getHashPath()', () => {
+    it('returns hash path from default param', () => {
+      window.location.hash = '#/projects/pr3';
+      const actual = routing.getHashPath();
+      const expected = 'projects/pr3';
+      assert.equal(actual, expected);
+    });
+
+    it('returns hash path from provided input param', () => {
+      const actual = routing.getHashPath('my-url#/projects/pr3');
+      const expected = 'projects/pr3';
+      assert.equal(actual, expected);
+    });
+  });
   describe('buildFromRelativePath', () => {
     const nodeWithParent = {
       link: 'child-node',


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix bug by applying refreshRoute event also to hash routing

**How to test it **

In the angular example app, enable hash routing and test it for example on  http://localhost:4200/#/projects/pr1/settings view. Click again on the node on the left navigation and check if the node is refreshed. On master branch it does not refresh, but in the current branch it does.