### PR TITLE
default icon for left nav item when it's collapsed

### DIFF
--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -36,7 +36,7 @@
               {/if}
               {:else}
               <span
-                class="fd-side-nav__icon sap-icon--l"
+                class="fd-side-nav__icon sap-icon--l {isSemiCollapsed ? 'sap-icon--rhombus-milestone-2' : ''}"
               ></span>
               {/if}
               <span


### PR DESCRIPTION
Changes proposed in this pull request:

- a default icon for the left nav item

Steps to test:

- go to `luigi-sample-angular/src/luigi-config/extended/settings.js` and change the settings to `responsiveNavigation = 'semiCollapsible'`;
- in `examples/luigi-sample-angular/src/luigi-config/extended/projectDetailNav.js` remove an icon from one of the nodes. (For example for the node `'Go to relative path'` remove  `icon: 'switch-views'`)
- in browser go to projects and collapse the left navigation. You will see now the default icon (`icon--rhombus`) instead of just an empty item.
