### PR TITLE
Side navigation - compact mode

### DIFF
--- a/core/examples/luigi-sample-angular/src/luigi-config/extended/navigation.js
+++ b/core/examples/luigi-sample-angular/src/luigi-config/extended/navigation.js
@@ -257,7 +257,7 @@ class Navigation {
         icon:
           'https://pbs.twimg.com/profile_images/1143452953858183170/QLk-HGmK_bigger.png',
         label: 'hybris',
-        subtitle: 'first subtitle',
+        subTitle: 'first subtitle',
         externalLink: {
           url: 'https://www.hybris.com',
           sameWindow: false

--- a/core/examples/luigi-sample-angular/src/luigi-config/extended/settings.js
+++ b/core/examples/luigi-sample-angular/src/luigi-config/extended/settings.js
@@ -13,6 +13,7 @@ class Settings {
   };
   responsiveNavigation = 'simpleMobileOnly'; // Options: simple | simpleMobileOnly | semiCollapsible
   sideNavFooterText = `Luigi Client: ${version || 'unknown'}`;
+  // sideNavCompactMode = true;
   // allowRules = ['microphone'];
   // iframeCreationInterceptor = (iframe, viewGroup, navigationNode, microFrontendType) => { };
   // hideNavigation = true

--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -13,7 +13,7 @@
       on:keyup="{handleKey}"
     >
       <div class="fd-side-nav__main-navigation">
-        <ul class="fd-nested-list">
+        <ul class="{sideNavClass}">
           {#each sortedChildrenEntries as [key, nodes]}
           {#if key === 'undefined' || key.startsWith(virtualGroupPrefix)}
           <!-- Single nodes -->
@@ -280,9 +280,12 @@
   export let selectedCategory = null;
   export let expandedCategories;
   export let hasCategoriesWithIcon;
+  export let sideNavClass;
   let context;
   let previousWindowWidth;
   let responsiveNavSetting;
+  let sideNavCompactMode;
+  let sideNavClass;
   let store = getContext('store');
   let getTranslation = getContext('getTranslation');
 
@@ -308,6 +311,9 @@
     hideNavComponent = LuigiConfig.getConfigBooleanValue(
       'settings.hideNavigation'
     );
+    sideNavCompactMode = LuigiConfig.getConfigBooleanValue(
+      'settings.sideNavCompactMode'
+    );
     expandedCategories = NavigationHelpers.loadExpandedCategories();
     previousWindowWidth = window.innerWidth;
 
@@ -328,6 +334,13 @@
     }
     const isSemiCollapsed = semiCollapsible ? getIsSemiCollapsed() : false;
     setIsSemiCollapsed(isSemiCollapsed);
+
+    // set compact mode class
+    if (Boolean(sideNavCompactMode)) {
+      sideNavClass = 'fd-nested-list fd-nested-list--compact';
+    } else {
+      sideNavClass = 'fd-nested-list';
+    }
   });
 
   beforeUpdate(() => {

--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -285,7 +285,6 @@
   let previousWindowWidth;
   let responsiveNavSetting;
   let sideNavCompactMode;
-  let sideNavClass;
   let store = getContext('store');
   let getTranslation = getContext('getTranslation');
 

--- a/core/src/navigation/ProductSwitcher.html
+++ b/core/src/navigation/ProductSwitcher.html
@@ -168,7 +168,7 @@ Object.keys(productSwitcherItems[0]).length }
   function setColumnsClass() {
     const columns = NavigationHelpers.getProductSwitcherColumnsNumber();
     if (columns === 3) {
-      columnsClass = 'fd-product-switch__body--col-3';
+      columnsClass = 'fd-product-switch__body fd-product-switch__body--col-3';
     } else {
       columnsClass = 'fd-product-switch__body';
     }

--- a/core/src/navigation/ProductSwitcher.html
+++ b/core/src/navigation/ProductSwitcher.html
@@ -162,7 +162,7 @@ Object.keys(productSwitcherItems[0]).length }
   }
 
   function getNodeSubtitle(node) {
-    return LuigiI18N.getTranslation(node.subtitle);
+    return LuigiI18N.getTranslation(node.subTitle);
   }
 
   function setColumnsClass() {

--- a/docs/general-settings.md
+++ b/docs/general-settings.md
@@ -59,7 +59,7 @@ You can set the following values:
   * `semiCollapsible` displays the arrow button at the bottom of the left side navigation. Once you click the button, the navigation shows up or collapses.<br>
 If you don't specify any value for  **responsiveNavigation**, the buttons remain hidden. The same applies when you enable **hideSideNav** for the currently active navigation node.
 * **sideNavFooterText** is a string displayed in a sticky footer inside the side navigation. It is a good place to display the version of your application.
-* **sideNavCompactMode** reduces dimensions of the side navigation and allows you to display more information.
+* **sideNavCompactMode** reduces the dimensions of the side navigation and allows you to display more information.
 * **customTranslationImplementation** provides a custom localization implementation. It can be an Object or a Function returning an Object. This Object must provide the **getTranslation** Function as property:
 ```javascript
 {

--- a/docs/general-settings.md
+++ b/docs/general-settings.md
@@ -30,6 +30,7 @@ settings: {
     favicon: 'path/to/favicon.ico'
   },
   sideNavFooterText: 'MyLovelyApp 1.0.0',
+  sideNavCompactMode: false,
   customTranslationImplementation: () => {
     return {
       getTranslation: (key, interpolations, locale) => {
@@ -58,6 +59,7 @@ You can set the following values:
   * `semiCollapsible` displays the arrow button at the bottom of the left side navigation. Once you click the button, the navigation shows up or collapses.<br>
 If you don't specify any value for  **responsiveNavigation**, the buttons remain hidden. The same applies when you enable **hideSideNav** for the currently active navigation node.
 * **sideNavFooterText** is a string displayed in a sticky footer inside the side navigation. It is a good place to display the version of your application.
+* **sideNavCompactMode** reduces dimensions of the side navigation and allows you to display more information.
 * **customTranslationImplementation** provides a custom localization implementation. It can be an Object or a Function returning an Object. This Object must provide the **getTranslation** Function as property:
 ```javascript
 {

--- a/docs/navigation-parameters-reference.md
+++ b/docs/navigation-parameters-reference.md
@@ -349,7 +349,7 @@ The product switcher is a pop-up window available in the top navigation bar. It 
 - **description**: an array of objects, each one being a link to a Luigi navigation node or an external URL. An item can have several attributes.
 - **attributes**:
   - **label** defines the text for the link.
-  - **subtitle** defines additional text line for the link.
+  - **subTitle** defines additional text line for the link.
   - **testId** is a string where you can define your own custom `testId`. If nothing is specified, it is the node's label written as one word and lower case (e.g. `label`).
   - **icon** is the name of an icon from the [OpenUI](https://openui5.hana.ondemand.com/1.40.10/iconExplorer.html) or a custom link (relative or absolute) to an image displayed next to the label or instead of it.
   - **altText** adds the HTML `alt` attribute to an icon. Note that this property only applies to icons with a defined absolute or relative path.


### PR DESCRIPTION
This is a part of **switch to fundamental styles**.

Changes:
- Adds possibility to display side navigation in compact mode
- Adds explanation in the documentation

To test, in settings of Luigi set **sideNavCompactMode** to `true`. By default is `false`.