### PR TITLE
Product switcher changes

### DIFF
--- a/core/src/navigation/ProductSwitcher.html
+++ b/core/src/navigation/ProductSwitcher.html
@@ -106,6 +106,7 @@ Object.keys(productSwitcherItems[0]).length }
   export let isMobile;
   export let config;
   export let dropDownStates;
+
   let store = getContext('store');
   let getUnsavedChangesModalPromise = getContext(
     'getUnsavedChangesModalPromise'


### PR DESCRIPTION
This is a part of **switch to fundamental styles**.

Changes in this pull request are already merged. This is a draft pull request to have a better overview of what's done and to make it easy to test.

Changes:
- Add the possibility to display products in 3 or 4 columns.
- Add the possibility to display the subtitle of each product.
- Add unit test. 
- Add explanation in the documentation.

To test columns of products, go to `luigi-sample-angular/src/luigi-config/extended/navigation.js` and for `prouctSwitcher` set `columns` to `3` or `4`. By default is `4`.

To test subtitle of each product, go to the same file (`.../navigation.js`) and inside of `getProductSwitcherItems` edit one of the items and add `subtitle: 'first subtitle'`.