### PR TITLE
1037 add burger semicollapsible mode

### DIFF
--- a/core/examples/luigi-sample-angular/src/luigi-config/extended/settings.js
+++ b/core/examples/luigi-sample-angular/src/luigi-config/extended/settings.js
@@ -11,7 +11,7 @@ class Settings {
   appLoadingIndicator = {
     hideAutomatically: false
   };
-  responsiveNavigation = 'simpleMobileOnly'; // Options: simple | simpleMobileOnly | semiCollapsible
+  responsiveNavigation = 'simpleMobileOnly'; // Options: simple | simpleMobileOnly | semiCollapsible | Fiori3
   sideNavFooterText = `Luigi Client: ${version || 'unknown'}`;
   thirdPartyCookieCheck = {
     // thirdPartyCookieScriptLocation: 'https://domain/init.html',

--- a/core/src/App.html
+++ b/core/src/App.html
@@ -1020,7 +1020,7 @@
     } else if (responsiveNavSetting === 'simpleMobileOnly') {
       document.body.classList.add('lui-simpleSlideInNav', 'lui-mobileOnly');
       simpleSlideInNav = true;
-    } else if (responsiveNavSetting === 'semiCollapsible') {
+    } else if (responsiveNavSetting === 'semiCollapsible' || 'Fiori3') {
       document.body.classList.add('lui-semiCollapsible');
     }
     thirdPartyCookiesCheck = LuigiConfig.getConfigValue(

--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -4,7 +4,7 @@
   on:blur="{closePopupMenu}"
 />
 <div
-  class="fd-app__sidebar {hideNavComponent ? 'hideNavComponent' : ''} {footerText || semiCollapsible ? 'hasFooter' : ''}"
+  class="fd-app__sidebar {hideNavComponent ? 'hideNavComponent' : ''} {footerText || semiCollapsibleButton ? 'hasFooter' : ''} {footerText && !semiCollapsibleButton ? 'hasOnlyFooterText' : ''}"
 >
   <nav
     class="fd-side-nav {isSemiCollapsed ? 'fd-side-nav--condensed' : ''}"
@@ -201,13 +201,13 @@
       </div>
     </div>
     {/if}
-    {#if footerText || semiCollapsible}
+    {#if footerText || semiCollapsibleButton}
     <div class="fd-side-nav__utility">
       <span class="lui-side-nav__footer">
         <span
           class="lui-side-nav__footer--text fd-has-type-minus-1"
         >{footerText ? footerText : ''}</span>
-        {#if semiCollapsible}
+        {#if semiCollapsibleButton}
         <span
           class="lui-side-nav__footer--icon {isSemiCollapsed ? 'sap-icon--open-command-field' : 'sap-icon--close-command-field'}"
           on:click="{() => semiCollapsibleButtonClicked(this)}"
@@ -269,11 +269,13 @@
   import { LuigiConfig, LuigiElements, LuigiI18N } from '../core-api';
   import { StateHelpers } from '../utilities/helpers';
   import { CSS_BREAKPOINTS } from '../utilities/constants';
+  import { SemiCollapsibleNavigation } from './services/semi-collapsed-navigation';
 
   export let children;
   export let hideNavComponent;
   export let footerText;
   export let semiCollapsible;
+  export let semiCollapsibleButton;
   export let pathData;
   let previousPathData;
   export let virtualGroupPrefix = NavigationHelpers.virtualGroupPrefix;
@@ -305,10 +307,9 @@
   };
 
   onMount(() => {
-    responsiveNavSetting = LuigiConfig.getConfigValue(
-      'settings.responsiveNavigation'
-    );
-    semiCollapsible = responsiveNavSetting === 'semiCollapsible';
+    semiCollapsibleButton =
+      LuigiConfig.getConfigValue('settings.responsiveNavigation') ===
+      'semiCollapsible';
     hideNavComponent = LuigiConfig.getConfigBooleanValue(
       'settings.hideNavigation'
     );
@@ -316,7 +317,6 @@
       'settings.sideNavCompactMode'
     );
     expandedCategories = NavigationHelpers.loadExpandedCategories();
-    previousWindowWidth = window.innerWidth;
 
     StateHelpers.doOnStoreChange(
       store,
@@ -326,22 +326,18 @@
       ['settings.footer']
     );
 
-    // set isSemiCollapsed to true for mobile
-    if (
-      semiCollapsible &&
-      window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth
-    ) {
-      setIsSemiCollapsed(true);
-    }
-    const isSemiCollapsed = semiCollapsible ? getIsSemiCollapsed() : false;
-    setIsSemiCollapsed(isSemiCollapsed);
-
     // set compact mode class
     if (Boolean(sideNavCompactMode)) {
       sideNavClass = 'fd-nested-list fd-nested-list--compact';
     } else {
       sideNavClass = 'fd-nested-list';
     }
+    let arr = SemiCollapsibleNavigation.initial();
+    isSemiCollapsed = arr.isSemiCollapsed;
+    semiCollapsible = arr.semiCollapsible;
+    SemiCollapsibleNavigation.onValueChanged(arr => {
+      isSemiCollapsed = arr.isSemiCollapsed;
+    });
   });
 
   beforeUpdate(() => {
@@ -388,14 +384,16 @@
   // [svelte-upgrade suggestion]
   // review these functions and remove unnecessary 'export' keywords
   export function handleClick(node) {
-    if (getIsSemiCollapsed()) {
-      closePopupMenu();
+    if (SemiCollapsibleNavigation.getCollapsed()) {
+      selectedCategory = SemiCollapsibleNavigation.closePopupMenu(
+        selectedCategory
+      );
     }
     dispatch('handleClick', { node });
   }
 
   export function handleIconClick(nodeOrNodes, el) {
-    if (getIsSemiCollapsed()) {
+    if (SemiCollapsibleNavigation.getCollapsed()) {
       let selectedCat;
       let sideBar = document.getElementsByClassName('fd-app__sidebar')[0];
 
@@ -413,7 +411,9 @@
 
       // only close if same clicked
       if (selectedCat === selectedCategory) {
-        closePopupMenu();
+        selectedCategory = SemiCollapsibleNavigation.closePopupMenu(
+          selectedCategory
+        );
         return;
       }
 
@@ -457,15 +457,9 @@
   }
 
   export function onResize() {
-    if (semiCollapsible) {
-      const isDesktopToMobile =
-        window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth &&
-        previousWindowWidth >= CSS_BREAKPOINTS.desktopMinWidth;
-      if (isDesktopToMobile) {
-        setIsSemiCollapsed(true);
-      }
-      closePopupMenu();
-    }
+    let arr = SemiCollapsibleNavigation.onResize(selectedCategory);
+    isSemiCollapsed = arr.isSemiCollapsed;
+    selectedCategory = arr.selectedCategory;
   }
 
   export function handleKey(event) {
@@ -479,7 +473,7 @@
   }
 
   export function setExpandedState(nodes, value) {
-    if (getIsSemiCollapsed()) {
+    if (SemiCollapsibleNavigation.getCollapsed()) {
       return;
     }
 
@@ -489,49 +483,16 @@
     );
   }
 
-  export function getIsSemiCollapsed() {
-    return localStorage.getItem(NavigationHelpers.COL_NAV_KEY) === 'true';
-  }
-
-  export function setIsSemiCollapsed(state) {
-    document.body.classList.remove('semiCollapsed');
-    // add if true
-    if (state) {
-      document.body.classList.add('semiCollapsed');
-    }
-    // initial state
-    isSemiCollapsed = state;
-    localStorage.setItem(NavigationHelpers.COL_NAV_KEY, state);
-  }
-
   export function closePopupMenu() {
-    if (selectedCategory) {
-      selectedCategory = null;
-      document
-        .getElementsByClassName('fd-app__sidebar')[0]
-        .classList.remove('isBlocked');
-    }
+    selectedCategory = SemiCollapsibleNavigation.closePopupMenu(
+      selectedCategory
+    );
   }
 
-  export function semiCollapsibleButtonClicked(el) {
-    closePopupMenu();
+  function semiCollapsibleButtonClicked(el) {
+    isSemiCollapsed = SemiCollapsibleNavigation.buttonClicked();
     if (document.getElementsByClassName('fd-tabs').length > 0) {
       dispatch('resizeTabNav', {});
-    }
-    if (!getIsSemiCollapsed()) {
-      setIsSemiCollapsed(true);
-
-      //Force browser to re-render vertical scrollbar
-      document
-        .getElementsByClassName('lui-fd-side-nav-wrapper')[0]
-        .setAttribute('style', 'overflow-y:hidden;');
-      window.setTimeout(function() {
-        document
-          .getElementsByClassName('lui-fd-side-nav-wrapper')[0]
-          .setAttribute('style', 'overflow-y:auto;');
-      });
-    } else {
-      setIsSemiCollapsed(false);
     }
   }
 </script>
@@ -734,6 +695,9 @@
           padding-right: 14px;
         }
       }
+    }
+    .hasOnlyFooterText {
+      height: 100%;
     }
   }
   :global(.lui-flyout-sublist) {

--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -457,9 +457,11 @@
   }
 
   export function onResize() {
-    let stateArr = SemiCollapsibleNavigation.onResize(selectedCategory);
-    isSemiCollapsed = stateArr.isSemiCollapsed;
-    selectedCategory = stateArr.selectedCategory;
+    if (semiCollapsible) {
+      let stateArr = SemiCollapsibleNavigation.onResize(selectedCategory);
+      isSemiCollapsed = stateArr.isSemiCollapsed;
+      selectedCategory = stateArr.selectedCategory;
+    }
   }
 
   export function handleKey(event) {

--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -332,11 +332,11 @@
     } else {
       sideNavClass = 'fd-nested-list';
     }
-    let arr = SemiCollapsibleNavigation.initial();
-    isSemiCollapsed = arr.isSemiCollapsed;
-    semiCollapsible = arr.semiCollapsible;
-    SemiCollapsibleNavigation.onValueChanged(arr => {
-      isSemiCollapsed = arr.isSemiCollapsed;
+    let stateArr = SemiCollapsibleNavigation.initial();
+    isSemiCollapsed = stateArr.isSemiCollapsed;
+    semiCollapsible = stateArr.semiCollapsible;
+    SemiCollapsibleNavigation.onValueChanged(stateArr => {
+      isSemiCollapsed = stateArr.isSemiCollapsed;
     });
   });
 
@@ -457,9 +457,9 @@
   }
 
   export function onResize() {
-    let arr = SemiCollapsibleNavigation.onResize(selectedCategory);
-    isSemiCollapsed = arr.isSemiCollapsed;
-    selectedCategory = arr.selectedCategory;
+    let stateArr = SemiCollapsibleNavigation.onResize(selectedCategory);
+    isSemiCollapsed = stateArr.isSemiCollapsed;
+    selectedCategory = stateArr.selectedCategory;
   }
 
   export function handleKey(event) {

--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -697,7 +697,9 @@
       }
     }
     .hasOnlyFooterText {
-      height: 100%;
+      .fd-side-nav__main-navigation {
+        height: 100%;
+      }
     }
   }
   :global(.lui-flyout-sublist) {

--- a/core/src/navigation/TopNav.html
+++ b/core/src/navigation/TopNav.html
@@ -2,10 +2,10 @@
 {#if showTopNav}
 <div class="fd-shellbar {hideNavComponent ? 'hideNavComponent' : ''}">
   <div class="fd-shellbar__group fd-shellbar__group--product">
-    {#if responsiveNavSetting==="simple" || responsiveNavSetting==="simpleMobileOnly"}
+    {#if responsiveNavSetting==="simple" || responsiveNavSetting==="simpleMobileOnly" || responsiveNavSetting==="Fiori3"}
     <span
       class="sap-icon--menu2 lui-burger"
-      on:click="{burgerClicked}"
+      on:click="{burgerClickHandler}"
     ></span>
     {/if}
     <LogoTitle
@@ -337,6 +337,7 @@
     NavigationHelpers,
     StateHelpers
   } from '../utilities/helpers';
+  import { SemiCollapsibleNavigation } from './services/semi-collapsed-navigation';
 
   const dispatch = createEventDispatcher();
 
@@ -485,8 +486,26 @@
     }
   }
 
-  export function burgerClicked() {
+  function burgerClickHandler() {
+    if (
+      responsiveNavSetting === 'simple' ||
+      responsiveNavSetting === 'simpleMobileOnly'
+    ) {
+      simpleNav();
+    } else {
+      semicollapsedNav();
+    }
+  }
+
+  export function simpleNav() {
     document.body.classList.toggle('lui-leftNavToggle');
+    if (document.getElementsByClassName('fd-tabs').length > 0) {
+      dispatch('resizeTabNav', {});
+    }
+  }
+
+  export function semicollapsedNav() {
+    SemiCollapsibleNavigation.buttonClicked();
     if (document.getElementsByClassName('fd-tabs').length > 0) {
       dispatch('resizeTabNav', {});
     }

--- a/core/src/navigation/services/semi-collapsed-navigation.js
+++ b/core/src/navigation/services/semi-collapsed-navigation.js
@@ -2,30 +2,30 @@ import { NavigationHelpers } from '../../utilities/helpers';
 import { LuigiConfig } from '../../core-api';
 import { CSS_BREAKPOINTS } from '../../utilities/constants';
 
-let responsiveNavSetting;
-let semiCollapsible;
-let previousWindowWidth;
-
 class SemiCollapsibleNavigationClass {
   initial() {
-    responsiveNavSetting = LuigiConfig.getConfigValue(
+    this.responsiveNavSetting = LuigiConfig.getConfigValue(
       'settings.responsiveNavigation'
     );
-    semiCollapsible = responsiveNavSetting === 'semiCollapsible' || 'Fiori3';
+    this.semiCollapsible =
+      this.responsiveNavSetting === 'semiCollapsible' || 'Fiori3';
 
     // set this.isSemiCollapsed to true for mobile
     if (
-      semiCollapsible &&
+      this.semiCollapsible &&
       window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth
     ) {
       this.setCollapsed(true);
     }
-    this.isSemiCollapsed = semiCollapsible ? this.getCollapsed() : false;
+    this.isSemiCollapsed = this.semiCollapsible ? this.getCollapsed() : false;
     this.setCollapsed(this.isSemiCollapsed);
 
-    previousWindowWidth = window.innerWidth;
+    this.previousWindowWidth = window.innerWidth;
 
-    return { isSemiCollapsed: this.isSemiCollapsed, semiCollapsible };
+    return {
+      isSemiCollapsed: this.isSemiCollapsed,
+      semiCollapsible: this.semiCollapsible
+    };
   }
 
   onValueChanged(fn) {
@@ -37,10 +37,10 @@ class SemiCollapsibleNavigationClass {
   }
 
   onResize(selectedCategory) {
-    if (semiCollapsible) {
+    if (this.semiCollapsible) {
       const isDesktopToMobile =
         window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth &&
-        previousWindowWidth >= CSS_BREAKPOINTS.desktopMinWidth;
+        this.previousWindowWidth >= CSS_BREAKPOINTS.desktopMinWidth;
       if (isDesktopToMobile) {
         this.setCollapsed(true);
       }

--- a/core/src/navigation/services/semi-collapsed-navigation.js
+++ b/core/src/navigation/services/semi-collapsed-navigation.js
@@ -1,0 +1,107 @@
+import { NavigationHelpers } from '../../utilities/helpers';
+import { LuigiConfig } from '../../core-api';
+import { CSS_BREAKPOINTS } from '../../utilities/constants';
+
+let responsiveNavSetting;
+let semiCollapsible;
+let previousWindowWidth;
+
+class SemiCollapsibleNavigationClass {
+  initial() {
+    responsiveNavSetting = LuigiConfig.getConfigValue(
+      'settings.responsiveNavigation'
+    );
+    semiCollapsible = responsiveNavSetting === 'semiCollapsible' || 'Fiori3';
+
+    // set this.isSemiCollapsed to true for mobile
+    if (
+      semiCollapsible &&
+      window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth
+    ) {
+      this.setCollapsed(true);
+    }
+    this.isSemiCollapsed = semiCollapsible ? this.getCollapsed() : false;
+    this.setCollapsed(this.isSemiCollapsed);
+
+    previousWindowWidth = window.innerWidth;
+
+    return { isSemiCollapsed: this.isSemiCollapsed, semiCollapsible };
+  }
+
+  onValueChanged(fn) {
+    if (this.valueChangedFns) {
+      this.valueChangedFns.push(fn);
+    } else {
+      this.valueChangedFns = [fn];
+    }
+  }
+
+  onResize(selectedCategory) {
+    if (semiCollapsible) {
+      const isDesktopToMobile =
+        window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth &&
+        previousWindowWidth >= CSS_BREAKPOINTS.desktopMinWidth;
+      if (isDesktopToMobile) {
+        this.setCollapsed(true);
+      }
+      selectedCategory = this.closePopupMenu(selectedCategory);
+      return { isSemiCollapsed: this.isSemiCollapsed, selectedCategory };
+    }
+  }
+
+  setCollapsed(state) {
+    document.body.classList.remove('semiCollapsed');
+    // add if true
+    if (state) {
+      document.body.classList.add('semiCollapsed');
+    }
+    // initial state
+    this.isSemiCollapsed = state;
+    localStorage.setItem(NavigationHelpers.COL_NAV_KEY, state);
+
+    if (this.valueChangedFns instanceof Array) {
+      this.valueChangedFns.forEach(fn =>
+        fn({
+          isSemiCollapsed: this.isSemiCollapsed
+        })
+      );
+    }
+  }
+
+  getCollapsed() {
+    return localStorage.getItem(NavigationHelpers.COL_NAV_KEY) === 'true';
+  }
+
+  closePopupMenu(selectedCategory) {
+    if (selectedCategory) {
+      selectedCategory = null;
+      document
+        .getElementsByClassName('fd-app__sidebar')[0]
+        .classList.remove('isBlocked');
+    }
+    return selectedCategory;
+  }
+
+  buttonClicked(el) {
+    this.closePopupMenu();
+    if (!this.getCollapsed()) {
+      this.setCollapsed(true);
+
+      //Force browser to re-render vertical scrollbar
+      document
+        .getElementsByClassName('lui-fd-side-nav-wrapper')[0]
+        .setAttribute('style', 'overflow-y:hidden;');
+      window.setTimeout(function() {
+        document
+          .getElementsByClassName('lui-fd-side-nav-wrapper')[0]
+          .setAttribute('style', 'overflow-y:auto;');
+      });
+    } else {
+      this.setCollapsed(false);
+    }
+
+    return this.isSemiCollapsed;
+  }
+}
+
+export const SemiCollapsibleNavigation = new SemiCollapsibleNavigationClass();

--- a/core/src/navigation/services/semi-collapsed-navigation.js
+++ b/core/src/navigation/services/semi-collapsed-navigation.js
@@ -12,7 +12,6 @@ class SemiCollapsibleNavigationClass {
       this.responsiveNavSetting === 'Fiori3'
         ? true
         : false;
-    console.log(this.semiCollapsible);
     // set this.isSemiCollapsed to true for mobile
     if (
       this.semiCollapsible &&
@@ -40,16 +39,14 @@ class SemiCollapsibleNavigationClass {
   }
 
   onResize(selectedCategory) {
-    if (this.semiCollapsible) {
-      const isDesktopToMobile =
-        window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth &&
-        this.previousWindowWidth >= CSS_BREAKPOINTS.desktopMinWidth;
-      if (isDesktopToMobile) {
-        this.setCollapsed(true);
-      }
-      selectedCategory = this.closePopupMenu(selectedCategory);
-      return { isSemiCollapsed: this.isSemiCollapsed, selectedCategory };
+    const isDesktopToMobile =
+      window.innerWidth < CSS_BREAKPOINTS.desktopMinWidth &&
+      this.previousWindowWidth >= CSS_BREAKPOINTS.desktopMinWidth;
+    if (isDesktopToMobile) {
+      this.setCollapsed(true);
     }
+    selectedCategory = this.closePopupMenu(selectedCategory);
+    return { isSemiCollapsed: this.isSemiCollapsed, selectedCategory };
   }
 
   setCollapsed(state) {

--- a/core/src/navigation/services/semi-collapsed-navigation.js
+++ b/core/src/navigation/services/semi-collapsed-navigation.js
@@ -8,8 +8,11 @@ class SemiCollapsibleNavigationClass {
       'settings.responsiveNavigation'
     );
     this.semiCollapsible =
-      this.responsiveNavSetting === 'semiCollapsible' || 'Fiori3';
-
+      this.responsiveNavSetting === 'semiCollapsible' ||
+      this.responsiveNavSetting === 'Fiori3'
+        ? true
+        : false;
+    console.log(this.semiCollapsible);
     // set this.isSemiCollapsed to true for mobile
     if (
       this.semiCollapsible &&

--- a/docs/general-settings.md
+++ b/docs/general-settings.md
@@ -66,7 +66,8 @@ settings: {
 You can set the following values:
   * `simple` displays the button on the left side of the top navigation regardless of the browser window´s size.
   * `simpleMobileOnly` displays the button on the left side of the top navigation when the browser window is narrower than `600px`.
-  * `semiCollapsible` displays the arrow button at the bottom of the left side navigation. Once you click the button, the navigation shows up or collapses.<br>
+  * `semiCollapsible` displays the arrow button at the bottom of the left side navigation. Once you click the button, the navigation shows up or collapses.
+  * `Fiori3` displays the button on the left side of the top navigation. Once you click the button, the navigation shows up or collapses.<br>
 If you don't specify any value for  **responsiveNavigation**, the buttons remain hidden. The same applies when you enable **hideSideNav** for the currently active navigation node.
 * **sideNavFooterText** is a string displayed in a sticky footer inside the side navigation. It is a good place to display the version of your application.
 * **sideNavCompactMode** reduces the dimensions of the side navigation and allows you to display more information.


### PR DESCRIPTION
Changes proposed in this pull request:

- add Fiori3 semi collapsible navigation


Steps to reproduce:

in `luigi-sample-angular/src/luigi-config/extended/settings.js` set `responsiveNavigation = 'Fiori3';`

You will see the burger button in top left corner of Top Navigation. Click on it and left navigation will be collapsed/uncollapsed. It should be the same behaviour as for `responsiveNavigation = 'semiCollapsible';`

Please keep in mind to check the correct behaviour of all other types of left navigation ;)