### PR TITLE
Add fundamental library styles section to migration docu

### DIFF
--- a/docs/migration-to-v1.md
+++ b/docs/migration-to-v1.md
@@ -61,6 +61,6 @@ To install the plugins, follow these installation guides:
 
 Following an upgrade from SAP Fundamentals to Fundamental Library Styles, there were changes in the HTML structure. Some classes were renamed or removed completely. You can find the full list of Fundamental Library Styles changes [here](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes). 
 
-On Luigi side we renamed `lui-tendant-menu__control` class into `lui-ctx-switch-menu`.
+Within Luigi, we renamed the `lui-tendant-menu__control` class to `lui-ctx-switch-menu`.
 
 <!-- accordion:end -->

--- a/docs/migration-to-v1.md
+++ b/docs/migration-to-v1.md
@@ -59,7 +59,7 @@ To install the plugins, follow these installation guides:
 
 ### Fundamental Library Styles
 
-During switching from SAP Fundamentals to Fundamental Library Styles there were changes in the HTML structure. Some classes were renamed or removed completely. The full list of Fundamental Library Styles changes you can see [here](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes). 
+Following an upgrade from SAP Fundamentals to Fundamental Library Styles, there were changes in the HTML structure. Some classes were renamed or removed completely. You can find the full list of Fundamental Library Styles changes [here](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes). 
 
 On Luigi side we renamed `lui-tendant-menu__control` class into `lui-ctx-switch-menu`.
 

--- a/docs/migration-to-v1.md
+++ b/docs/migration-to-v1.md
@@ -57,4 +57,10 @@ To install the plugins, follow these installation guides:
 <!-- add-attribute:class:warning -->
 > **NOTE:** If you already had a custom provider defined, you only need to rename the provider key to `idpProvider`.
 
+### Fundamental Library Styles
+
+During switching from SAP Fundamentals to Fundamental Library Styles there were changes in the HTML structure. Some classes were renamed or removed completely. The full list of Fundamental Library Styles changes you can see [here](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes). 
+
+On Luigi side we renamed `lui-tendant-menu__control` class into `lui-ctx-switch-menu`.
+
 <!-- accordion:end -->


### PR DESCRIPTION
I've added this section to our migration docu

<img width="943" alt="fundamental library styles" src="https://user-images.githubusercontent.com/46446373/76212726-695aaf80-6209-11ea-8d58-bc327e07d5ab.png">
