### PR TITLE
fixing burger spacing

### DIFF
--- a/core/src/navigation/TopNav.html
+++ b/core/src/navigation/TopNav.html
@@ -605,7 +605,6 @@
   }
 
   .lui-burger {
-    margin-left: 8px;
     margin-right: 16px;
     cursor: pointer;
     color: var(--sapShell_TextColor, #fff);
@@ -620,12 +619,6 @@
   @media (min-width: 600px) {
     :global(.lui-mobileOnly) .lui-burger {
       display: none;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .lui-burger {
-      margin-left: -16px;
     }
   }
 


### PR DESCRIPTION
There were the old styles for burger button. Please set `responsiveNavigation` to  `simple` / `simpleMobileOnly`/ `Fiori3` and check that you don't have the same situation like on the screenshot (wrong spacing on the left side of burger button).

![image (6)](https://user-images.githubusercontent.com/46446373/76880903-aa416c80-6878-11ea-8e8c-88dffa10d1ba.png)
