### PR TITLE
increase token expiring date for test app

### DIFF
--- a/test/e2e-test-application/src/assets/auth-mock/login-mock.html
+++ b/test/e2e-test-application/src/assets/auth-mock/login-mock.html
@@ -74,7 +74,7 @@
        */
 
       window.onload = function() {
-        const expiresIn = 3600;
+        const expiresIn = 28800;
         let redirectUrl = decodeURIComponent(
           window.location.href.match(/redirect_uri=(.*?)(&|$)/)[1]
         );


### PR DESCRIPTION
Reason:
It is annoying if you are in a debug session and the tokes expires. I would set it to 8 hours. 