### PR TITLE
Add testing production build capability

### DIFF
--- a/core/examples/luigi-example-react/README.md
+++ b/core/examples/luigi-example-react/README.md
@@ -31,3 +31,8 @@ npm run build
 
 The build compiles and minimizes the source files for production usage.
 The build generates a `build` folder which you can serve using a web server.
+You can also test the production build locally using the command below: 
+
+```
+npm run serve
+```

--- a/core/examples/luigi-example-react/package.json
+++ b/core/examples/luigi-example-react/package.json
@@ -70,7 +70,8 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js"
+    "test": "node scripts/test.js",
+    "serve": "node scripts/server.js build"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/core/examples/luigi-example-react/scripts/server.js
+++ b/core/examples/luigi-example-react/scripts/server.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+var buildFolder = process.argv[2];
+app.use(express.static(path.join(__dirname, '../', buildFolder)));
+app.get('/*', function(req, res) {
+  res.sendFile(path.join(__dirname, '../', buildFolder, 'index.html'));
+});
+console.log('Serving on port: 9000');
+app.listen(9000);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- `npm run build` then `serve -s build` is the general 'npm' norm that is usually used for testing the react production build locally. Currently, using the simple 'serve' command doesn't seem to work [due to routing issues ](https://create-react-app.dev/docs/deployment/).
- This PR adds the custom command `npm run serve` that allows to test the luigi react app production build with no issues as well

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
