### PR TITLE
Fix modal content not displaying issue in Safari

### DIFF
--- a/core/src/Modal.html
+++ b/core/src/Modal.html
@@ -189,7 +189,7 @@
 <style type="text/scss">
   .iframeModalCtn {
     position: relative;
-    height: 100%;
+    height: 70vh;
     width: 100%;
     overflow: auto;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Fix #1609 

CSS's height 100% doesn't work in Safari this case. 
My solution is applying `viewport height` instead and it works fine, but I am not sure this is the best way.

Please feel free to make a comment if there is any other better solution. Thanks