### PR TITLE
Updating Auth API to allow dynamic logout

### DIFF
--- a/core/src/core-api/auth.js
+++ b/core/src/core-api/auth.js
@@ -1,5 +1,5 @@
 import { LuigiConfig } from './';
-import { AuthStoreSvc } from '../services';
+import { AuthStoreSvc, AuthLayerSvc } from '../services';
 
 /**
  * Authorization helpers
@@ -10,7 +10,7 @@ class LuigiAuth {
    * @private
    * @memberof Authorization
    */
-  constructor() {}
+  constructor() { }
 
   /**
    * Detects if authorization is enabled via configuration.
@@ -22,6 +22,19 @@ class LuigiAuth {
    */
   isAuthorizationEnabled() {
     return !!LuigiConfig.getConfigValue('auth.use');
+  }
+
+  /**
+   * Logout the user dynamically.
+   * This will run the same functionality as though the user clicked the logout button.
+   * @memberof Authorization
+   * @example
+   * Luigi.auth().logout();
+   */
+  logout() {
+    if (this.isAuthorizationEnabled()) {
+      AuthLayerSvc.logout();
+    }
   }
 
   /**
@@ -69,7 +82,7 @@ class LuigiAuth {
     if (!LuigiConfig.initialized) {
       console.warn(
         'Luigi Core is not initialized yet. Consider moving your code to the luigiAfterInit lifecycle hook. ' +
-          'Documentation: https://docs.luigi-project.io/docs/lifecycle-hooks'
+        'Documentation: https://docs.luigi-project.io/docs/lifecycle-hooks'
       );
     }
     return {

--- a/docs/luigi-core-api.md
+++ b/docs/luigi-core-api.md
@@ -297,6 +297,15 @@ Luigi.auth().isAuthorizationEnabled();
 
 Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** `true` if authorization is enabled. Otherwise returns `false`.
 
+### logout
+Logs out the user dynamically and runs the logout flow. Running this function is the same as clicking the logout button.
+
+##### Examples
+
+```javascript
+Luigi.auth().logout();
+```
+
 ### AuthorizationStore
 
 Authorization Storage helpers, to be used in your custom authorization provider.

--- a/test/e2e-test-application/e2e/tests/1-angular/auth.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/auth.spec.js
@@ -1,0 +1,26 @@
+Cypress.env('RETRIES', 1);
+describe('Authorization', () => {
+  beforeEach(() => {
+    cy.visit('/', {
+      onBeforeLoad: () => cy.clearLocalStorage()
+    });
+  });
+
+  describe('Auth logout', () => {
+    it('Should logout dynamically', () => {
+      cy.login('tets@gmail.com', 'tets');
+
+      //logout dynamically
+      cy.window().then(win => {
+        win.Luigi.auth().logout();
+      });
+
+      //confirm redirect to logout page
+      cy.expectPathToBe('/logout.html');
+
+      //try to visit site, to verify that user was really logged out
+      cy.visit('/');
+      cy.expectPathToBe('/assets/auth-mock/login-mock.html');
+    });
+  });
+});


### PR DESCRIPTION
Added a logout function in the Auth API so that one can logout the user dynamically.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Auth API has a new function `logout()` which allows logging the user out dynamically
- Added separate spec file to test this functionality
