### PR TITLE
Fix flaky tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "./scripts/hooks/apply-formatters.sh && ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh && ./scripts/hooks/prevent-illegal-characters.sh"
+      "pre-commit": "./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh && ./scripts/hooks/prevent-illegal-characters.sh"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh && ./scripts/hooks/prevent-illegal-characters.sh"
+      "pre-commit": "./scripts/hooks/apply-formatters.sh && ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh && ./scripts/hooks/prevent-illegal-characters.sh"
     }
   }
 }

--- a/test/e2e-test-application/cypress.json
+++ b/test/e2e-test-application/cypress.json
@@ -1,4 +1,4 @@
 {
   "projectId": "czq7qc",
-  "retries": 3
+  "retries": 2
 }

--- a/test/e2e-test-application/e2e/support/commands.js
+++ b/test/e2e-test-application/e2e/support/commands.js
@@ -306,7 +306,6 @@ function onIframeReady($iframe, successFn, errorFn) {
  * returns the window instance of an iframe
  */
 Cypress.Commands.add('getIframeWindow', (num = 0) => {
-  cy.wait(100);
   return cy
     .get('iframe')
     .eq(num)

--- a/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
@@ -389,21 +389,35 @@ describe('Fiddle', () => {
         //   }
         // }
       };
-    });
-    it('Client get and set theme', () => {
-      cy.visitWithFiddleConfig('/', newConfig);
-
-      cy.getIframeWindow().then(win => {
-        // cypress workaround to fix travis flakiness
-        setTimeout(() => {
-          const defaultTheme = win.LuigiClient.uxManager().getCurrentTheme();
-          expect(defaultTheme).to.equal('light');
-        }, 0);
-
-        // not yet implemented
-        // win.LuigiClient.uxManager().setCurrentTheme('dark');
-        // expect(defaultTheme).to.equal('dark');
+      newConfig.navigation.nodes.push({
+        pathSegment: 'theming',
+        label: 'Theming Test',
+        viewUrl: '/examples/microfrontends/multipurpose.html#',
+        context: {
+          title: 'Welcome <h2 id="themeText"></h2>',
+          content: `<img src="empty.gif" onerror='document.getElementById("themeText").innerHTML = LuigiClient.uxManager().getCurrentTheme();' />`
+        }
       });
+    });
+
+    it('Client get and set theme', () => {
+      cy.visitWithFiddleConfig('/theming', newConfig);
+
+      cy.getIframeBody().then($body => {
+        cy.wrap($body)
+          .find('h2')
+          .contains('light');
+      });
+
+      // cy.getIframeWindow().then(win => {
+      //   // cypress workaround to fix travis flakiness
+      //     const defaultTheme = win.LuigiClient.uxManager().getCurrentTheme();
+      //     expect(defaultTheme).to.equal('light');
+
+      //   // not yet implemented
+      //   // win.LuigiClient.uxManager().setCurrentTheme('dark');
+      //   // expect(defaultTheme).to.equal('dark');
+      // });
     });
     it('Iframe Url should get set with value by default', () => {
       newConfig.settings.theming.nodeViewURLDecorator = {

--- a/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
@@ -59,7 +59,7 @@ describe('Fiddle', () => {
           // cypress workaround to fix travis flakiness
           setTimeout(() => {
             cy.expectPathToBe('/virtual/this/is/a/tree');
-          }, 0);
+          }, 50);
         });
       });
     });

--- a/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
@@ -56,8 +56,11 @@ describe('Fiddle', () => {
           win.LuigiClient.linkManager()
             .fromVirtualTreeRoot()
             .navigate('/this/is/a/tree');
+          // cypress workaround to fix travis flakiness
+          setTimeout(() => {
+            cy.expectPathToBe('/virtual/this/is/a/tree');
+          }, 0);
         });
-        cy.expectPathToBe('/virtual/this/is/a/tree');
       });
     });
     describe('ContextSwitcher', () => {
@@ -386,14 +389,16 @@ describe('Fiddle', () => {
     it('Client get and set theme', () => {
       cy.visitWithFiddleConfig('/', newConfig);
 
-      cy.wait(500);
       cy.getIframeWindow().then(win => {
+        // cypress workaround to fix travis flakiness
+        setTimeout(() => {
           const defaultTheme = win.LuigiClient.uxManager().getCurrentTheme();
           expect(defaultTheme).to.equal('light');
+        }, 0);
 
-          // not yet implemented
-          // win.LuigiClient.uxManager().setCurrentTheme('dark');
-          // expect(defaultTheme).to.equal('dark');
+        // not yet implemented
+        // win.LuigiClient.uxManager().setCurrentTheme('dark');
+        // expect(defaultTheme).to.equal('dark');
       });
     });
     it('Iframe Url should get set with value by default', () => {

--- a/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
@@ -43,7 +43,7 @@ describe('Fiddle', () => {
     describe('virtualTree with fromVirtualTreeRoot', () => {
       beforeEach(() => {
         const newConfig = cloneDeep(fiddleConfig);
-        // cy.log(newConfig);
+
         newConfig.navigation.nodes.push({
           pathSegment: 'virtual',
           label: 'Virtual',
@@ -408,16 +408,6 @@ describe('Fiddle', () => {
           .find('h2')
           .contains('light');
       });
-
-      // cy.getIframeWindow().then(win => {
-      //   // cypress workaround to fix travis flakiness
-      //     const defaultTheme = win.LuigiClient.uxManager().getCurrentTheme();
-      //     expect(defaultTheme).to.equal('light');
-
-      //   // not yet implemented
-      //   // win.LuigiClient.uxManager().setCurrentTheme('dark');
-      //   // expect(defaultTheme).to.equal('dark');
-      // });
     });
     it('Iframe Url should get set with value by default', () => {
       newConfig.settings.theming.nodeViewURLDecorator = {

--- a/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/0-fiddle/fiddle-navigation.spec.js
@@ -43,23 +43,27 @@ describe('Fiddle', () => {
     describe('virtualTree with fromVirtualTreeRoot', () => {
       beforeEach(() => {
         const newConfig = cloneDeep(fiddleConfig);
+        // cy.log(newConfig);
         newConfig.navigation.nodes.push({
           pathSegment: 'virtual',
           label: 'Virtual',
           virtualTree: true,
-          viewUrl: '/examples/microfrontends/multipurpose.html#'
+          viewUrl: '/examples/microfrontends/multipurpose.html#',
+          context: {
+            content:
+              '<button  onClick="LuigiClient.linkManager().fromVirtualTreeRoot().navigate(\'/this/is/a/tree\')">virtual</button>'
+          }
         });
         cy.visitWithFiddleConfig('/virtual', newConfig);
       });
       it('navigate', () => {
-        cy.getIframeWindow().then(win => {
-          win.LuigiClient.linkManager()
-            .fromVirtualTreeRoot()
-            .navigate('/this/is/a/tree');
-          // cypress workaround to fix travis flakiness
-          setTimeout(() => {
-            cy.expectPathToBe('/virtual/this/is/a/tree');
-          }, 50);
+        cy.getIframeBody().then($body => {
+          cy.wrap($body)
+            .find('button')
+            .contains('virtual')
+            .click();
+
+          cy.expectPathToBe('/virtual/this/is/a/tree');
         });
       });
     });

--- a/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
@@ -29,8 +29,8 @@ describe('Navigation', () => {
           collapsed: false
         });
         setTimeout(() => {
-        cy.get('#splitViewContainer').should('be.visible');
-        cy.expect(handle.exists()).to.be.true;
+          cy.get('#splitViewContainer').should('be.visible');
+          cy.expect(handle.exists()).to.be.true;
         }, 0);
         // It is not totally clear why it is not working without timeout, but it seems like a race condition
         // TODO: Check stackoverflow for solution
@@ -76,7 +76,9 @@ describe('Navigation', () => {
           collapsed: true
         });
         cy.get('#splitViewContainer').should('be.visible');
-        cy.get('.fd-shellbar').contains('Projects').click();
+        cy.get('.fd-shellbar')
+          .contains('Projects')
+          .click();
         cy.expectPathToBe('/projects');
         cy.get('#splitViewContainer').should('not.be.visible');
       });
@@ -206,7 +208,6 @@ describe('Navigation', () => {
           .contains('defaultChildNode')
           .click();
         cy.expectPathToBe('/projects/pr1/dps/dps2');
-
         cy.window().historyBack();
         cy.expectPathToBe('/overview');
       });
@@ -317,43 +318,47 @@ describe('Navigation', () => {
   */
 
   describe('features', () => {
-    it('keepSelectedForChildren', {
-      retries: {
-        runMode: 3,
-        openMode: 3
+    it(
+      'keepSelectedForChildren',
+      {
+        retries: {
+          runMode: 3,
+          openMode: 3
+        }
+      },
+      () => {
+        // keep selected for children example
+        cy.get('.fd-shellbar')
+          .contains('Overview')
+          .click();
+
+        cy.wait(500);
+        // dig into the iframe
+
+        cy.getIframeBody().then($iframeBody => {
+          cy.wrap($iframeBody)
+            .find('.fd-list__item')
+            .contains('keepSelectedForChildren')
+            .click();
+          cy.wait(500);
+        });
+
+        cy.expectPathToBe('/projects/pr1/avengers');
+
+        //the iframe is has been replaced with another one, we need to "get" it again
+        cy.getIframeBody().then($iframeBody => {
+          // wrap this body with cy so as to do cy actions inside iframe elements
+          cy.wrap($iframeBody)
+            .find('.fd-list__item')
+            .contains('Thor')
+            .click();
+          cy.wait(500);
+        });
+        cy.expectPathToBe('/projects/pr1/avengers/thor');
+
+        cy.get('.fd-app__sidebar').should('contain', 'Keep Selected Example');
       }
-    }, () => {
-      // keep selected for children example
-      cy.get('.fd-shellbar')
-        .contains('Overview')
-        .click();
-
-      cy.wait(500);
-      // dig into the iframe
-
-      cy.getIframeBody().then($iframeBody => {
-        cy.wrap($iframeBody)
-          .find('.fd-list__item')
-          .contains('keepSelectedForChildren')
-          .click();
-        cy.wait(500);
-      });
-
-      cy.expectPathToBe('/projects/pr1/avengers');
-
-      //the iframe is has been replaced with another one, we need to "get" it again
-      cy.getIframeBody().then($iframeBody => {
-        // wrap this body with cy so as to do cy actions inside iframe elements
-        cy.wrap($iframeBody)
-          .find('.fd-list__item')
-          .contains('Thor')
-          .click();
-        cy.wait(500);
-      });
-      cy.expectPathToBe('/projects/pr1/avengers/thor');
-
-      cy.get('.fd-app__sidebar').should('contain', 'Keep Selected Example');
-    });
+    );
 
     it('Node with link to another node', () => {
       const goToAnotherNodeFeature = () => {
@@ -706,47 +711,88 @@ describe('Navigation', () => {
     it('It should have multiple categories collapsed', () => {
       cy.visit('/projects/pr2/collapsibles');
 
-      cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
+      cy.get(
+        'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+      ).should('not.be.visible');
+      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+        'not.be.visible'
+      );
 
-      cy.get('li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]').click()
-      cy.get('li[data-testid="usermanagement"] a[title="User Management"]').click()
+      cy.get(
+        'li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]'
+      ).click();
+      cy.get(
+        'li[data-testid="usermanagement"] a[title="User Management"]'
+      ).click();
 
-      cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('be.visible')
-      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('be.visible')
+      cy.get(
+        'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+      ).should('be.visible');
+      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+        'be.visible'
+      );
 
-      cy.get('li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]').click()
-      cy.get('li[data-testid="usermanagement"] a[title="User Management"]').click()
+      cy.get(
+        'li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]'
+      ).click();
+      cy.get(
+        'li[data-testid="usermanagement"] a[title="User Management"]'
+      ).click();
 
-      cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
+      cy.get(
+        'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+      ).should('not.be.visible');
+      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+        'not.be.visible'
+      );
     });
 
     it('It should have a local side nav accordion mode', () => {
       cy.visit('/projects/pr2/sidenavaccordionmode');
 
-
       // All is closed
-      cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
+      cy.get(
+        'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+      ).should('not.be.visible');
+      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+        'not.be.visible'
+      );
 
-      cy.get('li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]').click()
+      cy.get(
+        'li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]'
+      ).click();
 
       // First one is open only
-      cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('be.visible')
-      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
+      cy.get(
+        'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+      ).should('be.visible');
+      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+        'not.be.visible'
+      );
 
-      cy.get('li[data-testid="usermanagement"] a[title="User Management"]').click()
+      cy.get(
+        'li[data-testid="usermanagement"] a[title="User Management"]'
+      ).click();
 
       // Second one is open only
-      cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('be.visible')
+      cy.get(
+        'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+      ).should('not.be.visible');
+      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+        'be.visible'
+      );
 
-      cy.get('li[data-testid="usermanagement"] a[title="User Management"]').click()
+      cy.get(
+        'li[data-testid="usermanagement"] a[title="User Management"]'
+      ).click();
 
       // All is closed
-      cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
+      cy.get(
+        'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+      ).should('not.be.visible');
+      cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+        'not.be.visible'
+      );
     });
 
     it('It should have a global side nav accordion mode', () => {
@@ -755,33 +801,52 @@ describe('Navigation', () => {
         const config = win.Luigi.getConfig();
         config.navigation.defaults = {
           sideNavAccordionMode: true
-        }
+        };
         win.Luigi.configChanged('settings.navigation');
         // All is closed
-        cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
+        cy.get(
+          'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+        ).should('not.be.visible');
+        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+          'not.be.visible'
+        );
 
-        cy.get('li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]').click()
+        cy.get(
+          'li[data-testid="superusefulgithublinks"] a[title="Super useful Github links"]'
+        ).click();
 
         // First one is open only
-        cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('be.visible')
-        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
+        cy.get(
+          'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+        ).should('be.visible');
+        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+          'not.be.visible'
+        );
 
-        cy.get('li[data-testid="usermanagement"] a[title="User Management"]').click()
+        cy.get(
+          'li[data-testid="usermanagement"] a[title="User Management"]'
+        ).click();
 
         // Second one is open only
-        cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('be.visible')
+        cy.get(
+          'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+        ).should('not.be.visible');
+        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+          'be.visible'
+        );
 
-        cy.get('li[data-testid="usermanagement"] a[title="User Management"]').click()
+        cy.get(
+          'li[data-testid="usermanagement"] a[title="User Management"]'
+        ).click();
 
         // All is closed
-        cy.get('li[data-testid="superusefulgithublinks"]>ul.fd-nested-list').should('not.be.visible')
-        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should('not.be.visible')
-
-      })
+        cy.get(
+          'li[data-testid="superusefulgithublinks"]>ul.fd-nested-list'
+        ).should('not.be.visible');
+        cy.get('li[data-testid="usermanagement"]>ul.fd-nested-list').should(
+          'not.be.visible'
+        );
+      });
     });
-  })
-
-
+  });
 });

--- a/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
@@ -28,9 +28,10 @@ describe('Navigation', () => {
           size: '40',
           collapsed: false
         });
+        setTimeout(() => {
         cy.get('#splitViewContainer').should('be.visible');
         cy.expect(handle.exists()).to.be.true;
-
+        }, 0);
         // It is not totally clear why it is not working without timeout, but it seems like a race condition
         // TODO: Check stackoverflow for solution
         // https://stackoverflow.com/questions/60338487/cypress-executes-assertion-immediately-on-function-that-returns-a-handle
@@ -580,7 +581,7 @@ describe('Navigation', () => {
         cy.get('.luigi-tabsContainer').within(() => {
           cy.get('.fd-tabs__item')
             .contains('User Management')
-            .should('visible');
+            .should('be.visible');
           cy.get('.fd-tabs__item')
             .contains('Node with node activation hook')
             .should('not.visible');
@@ -592,7 +593,7 @@ describe('Navigation', () => {
         cy.get('.luigi-tabsContainer').within(() => {
           cy.get('.fd-tabs__item')
             .contains('Settings')
-            .should('visible');
+            .should('be.visible');
           cy.get('.fd-tabs__item')
             .contains('Settings')
             .click();
@@ -625,7 +626,7 @@ describe('Navigation', () => {
           cy.wait(1000);
           cy.get('.fd-tabs__item')
             .contains('Miscellaneous2')
-            .should('visible');
+            .should('be.visible');
         });
       });
     });

--- a/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
@@ -66,7 +66,7 @@ describe('Navigation', () => {
         cy.expect(handle.isExpanded()).to.be.true;
       });
     });
-    it.only('Core API open collapsed splitview and check if expand container will disappear after navigation', () => {
+    it('Core API open collapsed splitview and check if expand container will disappear after navigation', () => {
       cy.get('.fd-shellbar').should('be.visible');
       cy.window().then(win => {
         const handle = win.Luigi.navigation().openAsSplitView('/overview', {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

It appears that cypress doesn't wait for custom functions such as functions we expose globally via our APIs: 
The following code flow can **easily** result in a flaky test: 
 
_// Checkpoint 1 : **current path = /virtual**_
         `win.LuigiClient.linkManager().fromVirtualTreeRoot().navigate('/this/is/a/tree');`
_// Checkpoint 2 : **current path = /virtual**  or **current path = /virtual/this/is/a/tree**  depending on ur 'luck'_
         `cy.expectPathToBe('/virtual/this/is/a/tree'); `

Cypress only waits on cypress commands or cypress assertions but not our LuigiClient methods since [it cannot know ](https://stackoverflow.com/a/57820813)when the event fired is finished. At our current state a passing state is pure luck.

### **TLDR; Changes made in following tests:** 
 in **fiddle-navigation.spec.js** : 
- _virtualTree with fromVirtualTreeRoot_  --> **(avoid calling window.LuigiClient directly)**
- _Client get and set theme_ --> **(avoid calling window.LuigiClient directly)**

 in **navigation.spec.js** : 
- _Core API open and close in SplitView_ --> **(avoid race condition)**
- _recalc of tab nav by using resizing_ --> **(fix new syntax issue)**
- _ResponsiveNavigation Semicollapsed_ --> **(fix new syntax issue)**
- **everything else is prettier indentation**