### PR TITLE
Add WC API

### DIFF
--- a/core/src/services/web-components.js
+++ b/core/src/services/web-components.js
@@ -4,16 +4,21 @@ class WebComponentSvcClass {
 
   dynamicImport(viewUrl) {
     /** __luigi_dyn_import() is replaced by import() after webpack is done,
-         *    because webpack can't let his hands off imports ;) */
+     *    because webpack can't let his hands off imports ;) */
     return __luigi_dyn_import(viewUrl);
   }
 
   /** Creates a web component with tagname wc_id and adds it to wcItemContainer, if attached to wc_container*/
   attachWC(wc_id, wcItemContainer, wc_container, ctx) {
-    if(wc_container && wc_container.contains(wcItemContainer)) {
+    if (wc_container && wc_container.contains(wcItemContainer)) {
       const wc = document.createElement(wc_id);
       wc.context = ctx;
       wc.luigi = window.Luigi;
+      const clientAPI = {
+        linkManager: window.Luigi.navigation,
+        uxManager: window.Luigi.ux
+      };
+      wc.LuigiClient = clientAPI;
       wcItemContainer.appendChild(wc);
     }
   }
@@ -24,7 +29,7 @@ class WebComponentSvcClass {
    */
   generateWCId(viewUrl) {
     let charRep = '';
-    for(let i = 0; i < viewUrl.length; i++) {
+    for (let i = 0; i < viewUrl.length; i++) {
       charRep += viewUrl.charCodeAt(i).toString(16);
     }
     return 'luigi-wc-' + charRep;
@@ -35,14 +40,16 @@ class WebComponentSvcClass {
    * returns a promise that gets resolved after successfull import */
   registerWCFromUrl(viewUrl, wc_id) {
     return new Promise((resolve, reject) => {
-      this.dynamicImport(viewUrl).then(module => {
-        try {
-          window.customElements.define(wc_id, module.default);
-          resolve();
-        } catch(e) {
-          reject(e);
-        }
-      }).catch(err => reject(err));
+      this.dynamicImport(viewUrl)
+        .then(module => {
+          try {
+            window.customElements.define(wc_id, module.default);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        })
+        .catch(err => reject(err));
     });
   }
 
@@ -58,7 +65,7 @@ class WebComponentSvcClass {
       this.attachWC(wc_id, wcItemCnt, wc_container, context);
     } else {
       /** Custom import function, if defined */
-      if(window.luigiWCFn) {
+      if (window.luigiWCFn) {
         window.luigiWCFn(viewUrl, wc_id, wcItemCnt, () => {
           this.attachWC(wc_id, wcItemCnt, wc_container, context);
         });

--- a/core/src/services/web-components.js
+++ b/core/src/services/web-components.js
@@ -13,7 +13,6 @@ class WebComponentSvcClass {
     if (wc_container && wc_container.contains(wcItemContainer)) {
       const wc = document.createElement(wc_id);
       wc.context = ctx;
-      wc.luigi = window.Luigi;
       const clientAPI = {
         linkManager: window.Luigi.navigation,
         uxManager: window.Luigi.ux

--- a/core/test/services/web-components.spec.js
+++ b/core/test/services/web-components.spec.js
@@ -7,7 +7,8 @@ import { WebComponentService } from '../../src/services/web-components';
 
 describe('WebComponentService', function() {
   describe('generate web component id', function() {
-    const someRandomString = 'dsfgljhbakjdfngb,mdcn vkjrzwero78to4     wfoasb    f,asndbf';
+    const someRandomString =
+      'dsfgljhbakjdfngb,mdcn vkjrzwero78to4     wfoasb    f,asndbf';
 
     it('check determinism', () => {
       let wcId = WebComponentService.generateWCId(someRandomString);
@@ -17,7 +18,9 @@ describe('WebComponentService', function() {
 
     it('check uniqueness', () => {
       let wcId = WebComponentService.generateWCId(someRandomString);
-      let wcId2 = WebComponentService.generateWCId('someOtherRandomString_9843utieuhfgiasdf');
+      let wcId2 = WebComponentService.generateWCId(
+        'someOtherRandomString_9843utieuhfgiasdf'
+      );
       expect(wcId).to.not.equal(wcId2);
     });
   });
@@ -25,14 +28,13 @@ describe('WebComponentService', function() {
   describe('attach web component', function() {
     const container = document.createElement('div');
     const itemContainer = document.createElement('div');
-    const ctx = { someValue: true};
+    const ctx = { someValue: true };
 
-    before(()=>{
-      window.Luigi = { mario: 'luigi', luigi: window.luigi };
-    });
-
-    after(()=>{
-      window.Luigi = window.Luigi.luigi;
+    before(() => {
+      window.Luigi = {
+        linkManager: undefined,
+        uxManager: undefined
+      };
     });
 
     it('check dom injection abort if container not attached', () => {
@@ -47,79 +49,90 @@ describe('WebComponentService', function() {
 
       const expectedCmp = itemContainer.children[0];
       expect(expectedCmp.context).to.equal(ctx);
-      expect(expectedCmp.luigi).to.equal(window.Luigi);
+      expect(expectedCmp.LuigiClient).to.deep.equal(window.Luigi);
     });
   });
 
   describe('register web component from url', function() {
     const sb = sinon.createSandbox();
 
-    afterEach(()=>{
+    afterEach(() => {
       sb.restore();
     });
 
-    it('check resolve', (done) => {
+    it('check resolve', done => {
       let definedId;
-      sb.stub(WebComponentService, 'dynamicImport').returns(new Promise((resolve, reject) => {
-        resolve({ default: {} });
-      }));
-      window.customElements = { define: (id, clazz)=>{
-        definedId = id;
-      }};
+      sb.stub(WebComponentService, 'dynamicImport').returns(
+        new Promise((resolve, reject) => {
+          resolve({ default: {} });
+        })
+      );
+      window.customElements = {
+        define: (id, clazz) => {
+          definedId = id;
+        }
+      };
 
-      WebComponentService.registerWCFromUrl('url', 'id').then(()=>{
+      WebComponentService.registerWCFromUrl('url', 'id').then(() => {
         expect(definedId).to.equal('id');
         done();
       });
     });
 
-    it('check reject', (done) => {
+    it('check reject', done => {
       let definedId;
-      sb.stub(WebComponentService, 'dynamicImport').returns(new Promise((resolve, reject) => {
-        reject({ default: {} });
-      }));
-      window.customElements = { define: (id, clazz)=>{
-        definedId = id;
-      }};
+      sb.stub(WebComponentService, 'dynamicImport').returns(
+        new Promise((resolve, reject) => {
+          reject({ default: {} });
+        })
+      );
+      window.customElements = {
+        define: (id, clazz) => {
+          definedId = id;
+        }
+      };
 
-      WebComponentService.registerWCFromUrl('url', 'id').then(()=>{
-        assert(false, "should not be here");
-        done();
-      }).catch(err=>{
-        expect(definedId).to.be.undefined;
-        done();
-      });
+      WebComponentService.registerWCFromUrl('url', 'id')
+        .then(() => {
+          assert(false, 'should not be here');
+          done();
+        })
+        .catch(err => {
+          expect(definedId).to.be.undefined;
+          done();
+        });
     });
   });
 
   describe('render web component', function() {
     const container = document.createElement('div');
-    const ctx = { someValue: true};
+    const ctx = { someValue: true };
     const viewUrl = 'someurl';
     const sb = sinon.createSandbox();
 
-    before(()=>{
+    before(() => {
       window.Luigi = { mario: 'luigi', luigi: window.luigi };
     });
 
-    after(()=>{
+    after(() => {
       window.Luigi = window.Luigi.luigi;
     });
 
-    beforeEach(()=>{
-      sb.stub(WebComponentService, 'dynamicImport').returns(new Promise((resolve, reject) => {
-        resolve({ default: {} });
-      }));
+    beforeEach(() => {
+      sb.stub(WebComponentService, 'dynamicImport').returns(
+        new Promise((resolve, reject) => {
+          resolve({ default: {} });
+        })
+      );
     });
 
-    afterEach(()=>{
+    afterEach(() => {
       sb.restore();
     });
 
-
-    it('check attachment of already existing wc', (done) => {
+    it('check attachment of already existing wc', done => {
       window.customElements = {
-        define: (id, clazz)=>{
+        define: (id, clazz) => {
           definedId = id;
         },
         get: () => {
@@ -127,24 +140,26 @@ describe('WebComponentService', function() {
         }
       };
 
-      sb.stub(WebComponentService, 'registerWCFromUrl').callsFake(()=>{
-        assert(false, "should not be here");
+      sb.stub(WebComponentService, 'registerWCFromUrl').callsFake(() => {
+        assert(false, 'should not be here');
       });
 
-      sb.stub(WebComponentService, 'attachWC').callsFake((id, iCnt, cnt, context)=>{
-        expect(cnt).to.equal(container);
-        expect(context).to.equal(ctx);
-        done();
-      });
+      sb.stub(WebComponentService, 'attachWC').callsFake(
+        (id, iCnt, cnt, context) => {
+          expect(cnt).to.equal(container);
+          expect(context).to.equal(ctx);
+          done();
+        }
+      );
 
       WebComponentService.renderWebComponent(viewUrl, container, ctx);
     });
 
-    it('check invocation of custom function', (done) => {
+    it('check invocation of custom function', done => {
       let definedId;
 
       window.customElements = {
-        define: (id, clazz)=>{
+        define: (id, clazz) => {
           definedId = id;
         },
         get: () => {
@@ -152,28 +167,30 @@ describe('WebComponentService', function() {
         }
       };
 
-      sb.stub(WebComponentService, 'registerWCFromUrl').callsFake(()=>{
-        assert(false, "should not be here");
+      sb.stub(WebComponentService, 'registerWCFromUrl').callsFake(() => {
+        assert(false, 'should not be here');
       });
 
-      sb.stub(WebComponentService, 'attachWC').callsFake((id, iCnt, cnt, context)=>{
-        expect(cnt).to.equal(container);
-        expect(context).to.equal(ctx);
-        done();
-      });
+      sb.stub(WebComponentService, 'attachWC').callsFake(
+        (id, iCnt, cnt, context) => {
+          expect(cnt).to.equal(container);
+          expect(context).to.equal(ctx);
+          done();
+        }
+      );
 
       window.luigiWCFn = (viewUrl, wc_id, wc_container, cb) => {
         cb();
-      }
+      };
 
       WebComponentService.renderWebComponent(viewUrl, container, ctx);
     });
 
-    it('check creation and attachment of new wc', (done) => {
+    it('check creation and attachment of new wc', done => {
       let definedId;
 
       window.customElements = {
-        define: (id, clazz)=>{
+        define: (id, clazz) => {
           definedId = id;
         },
         get: () => {
@@ -181,20 +198,21 @@ describe('WebComponentService', function() {
         }
       };
 
-      sb.stub(WebComponentService, 'registerWCFromUrl').callsFake(()=>{
+      sb.stub(WebComponentService, 'registerWCFromUrl').callsFake(() => {
         return new Promise((resolve, reject) => {
           resolve();
-        })
+        });
       });
 
-      sb.stub(WebComponentService, 'attachWC').callsFake((id, iCnt, cnt, context)=>{
-        expect(cnt).to.equal(container);
-        expect(context).to.equal(ctx);
-        done();
-      });
+      sb.stub(WebComponentService, 'attachWC').callsFake(
+        (id, iCnt, cnt, context) => {
+          expect(cnt).to.equal(container);
+          expect(context).to.equal(ctx);
+          done();
+        }
+      );
 
       WebComponentService.renderWebComponent(viewUrl, container, ctx);
     });
   });
 });
-

--- a/test/e2e-test-application/e2e/tests/1-angular/luigi-client-link-manager-features.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/luigi-client-link-manager-features.spec.js
@@ -87,10 +87,18 @@ describe('Luigi client linkManager', () => {
           .contains('Open webcomponent in splitView')
           .click();
         cy.get('.iframeSplitViewCnt>div>').then(container => {
-          const wcContent = container
-            .children()
-            .prevObject[0].shadowRoot.querySelector('p').innerText;
+          const root = container.children().prevObject[0].shadowRoot;
+          const wcContent = root.querySelector('p').innerText;
           expect(wcContent).to.equal('Hello WebComponent!');
+          root.querySelector('button').click();
+          cy.get('[data-testid=luigi-alert]').should(
+            'have.class',
+            'fd-message-strip--information'
+          );
+          cy.get('[data-testid=luigi-alert]').should(
+            'contain',
+            'Hello from uxManager in Web Component'
+          );
         });
         //navigate with intent
         cy.wrap($iframeBody)

--- a/test/e2e-test-application/src/assets/helloWorldWC.js
+++ b/test/e2e-test-application/src/assets/helloWorldWC.js
@@ -3,13 +3,29 @@ export default class extends HTMLElement {
     super();
     const template = document.createElement('template');
     template.innerHTML = `<section><p>Hello World!</p></section>`;
+
+    const templateBtn = document.createElement('template');
+    templateBtn.innerHTML = '<button>Click me!</button>';
+
     this._shadowRoot = this.attachShadow({
       mode: 'open',
       delegatesFocus: false
     });
     this._shadowRoot.appendChild(template.content.cloneNode(true));
+    this._shadowRoot.appendChild(templateBtn.content.cloneNode(true));
+
     this.$paragraph = this._shadowRoot.querySelector('p');
+    this.$button = this._shadowRoot.querySelector('button');
+    this.$button.addEventListener('click', () => {
+      if (this.LuigiClient) {
+        this.LuigiClient.uxManager().showAlert({
+          text: 'Hello from uxManager in Web Component',
+          type: 'info'
+        });
+      }
+    });
   }
+
   set context(ctx) {
     this.$paragraph.innerHTML = ctx.title;
   }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Resolves #1546 

Changes proposed in this pull request:
- Currently we expose the whole luigi object to the web component, which is then used to call api functions upon. This can result in misuses on the client web-component developers, i.e.: they might override the object, or might use api calls that would not be client but core related. 
- This PR exposes only parts of the core that makes sense in the client perspective, currently its **uxManager** and **linkManager** but it can be extended later. 
- You can access client api in this form : **this.LuigiClient.uxManager()** instead of _this.luigi.ux()_
