### PR TITLE
Disable micro-frontend cache while switching different userSettingsGroup

### DIFF
--- a/core/src/services/iframe.js
+++ b/core/src/services/iframe.js
@@ -204,7 +204,7 @@ class IframeClass {
     if (viewUrl) {
       viewUrl = RoutingHelpers.substituteViewUrl(viewUrl, componentData);
     }
-    const isSameViewGroup = IframeHelpers.isSameViewGroup(config, component);
+    const isSameViewGroup = IframeHelpers.isSameViewGroup(component.get());
     const previousViewIsolated = this.hasIsolatedView(
       componentData.previousNodeValues.isolateView,
       isSameViewGroup,
@@ -215,7 +215,7 @@ class IframeClass {
       isSameViewGroup,
       config.isolateAllViews
     );
-    const canReuseIframe = IframeHelpers.canReuseIframe(config, component);
+    const canReuseIframe = IframeHelpers.canReuseIframe(config.iframe, component.get());
     let activeIframe = this.getActiveIframe(node);
 
     const iframes = IframeHelpers.getMainIframes();

--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -327,7 +327,8 @@ class RoutingClass {
             ? {
                 viewUrl: previousCompData.viewUrl,
                 isolateView: previousCompData.isolateView,
-                viewGroup: previousCompData.viewGroup
+                viewGroup: previousCompData.viewGroup,
+                userSettingsGroup: (previousCompData.currentNode) ? previousCompData.currentNode.userSettingsGroup : undefined
               }
             : {}
         })

--- a/core/src/utilities/helpers/iframe-helpers.js
+++ b/core/src/utilities/helpers/iframe-helpers.js
@@ -83,52 +83,50 @@ class IframeHelpersClass {
     return processedUrl;
   }
 
-  isSameDomain(config, component) {
-    //TODO rename to reflect the fact that it checks for URL till hash (which is more than just domain)
-    if (config.iframe) {
-      const componentData = component.get();
-      const previousUrl = GenericHelpers.getUrlWithoutHash(
-        componentData.previousNodeValues.viewUrl
-      );
-      const nextUrl = GenericHelpers.getUrlWithoutHash(componentData.viewUrl);
-      const previousViewGroup = componentData.previousNodeValues.viewGroup;
-      const nextViewGroup = componentData.viewGroup;
-      if (previousUrl === nextUrl && !previousViewGroup && !nextViewGroup) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  isSameViewGroup(config, component) {
-    if (config.iframe) {
-      const componentData = component.get();
-      const previousUrl = GenericHelpers.getUrlWithoutHash(
-        componentData.previousNodeValues.viewUrl
-      );
-      const nextUrl = GenericHelpers.getUrlWithoutHash(componentData.viewUrl);
-      const previousUrlOrigin = this.getLocation(previousUrl);
-      const nextUrlOrigin = this.getLocation(nextUrl);
-      if (previousUrlOrigin === nextUrlOrigin) {
-        const previousViewGroup = componentData.previousNodeValues.viewGroup;
-        const nextViewGroup = componentData.viewGroup;
-        if (
-          previousViewGroup &&
-          nextViewGroup &&
-          previousViewGroup === nextViewGroup
-        ) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  canReuseIframe(config, component) {
-    return (
-      this.isSameDomain(config, component) ||
-      this.isSameViewGroup(config, component)
+  isSameViewUrl(componentData) {
+    const previousUrl = GenericHelpers.getUrlWithoutHash(
+      componentData.previousNodeValues.viewUrl
     );
+    const nextUrl = GenericHelpers.getUrlWithoutHash(componentData.viewUrl);
+    const previousViewGroup = componentData.previousNodeValues.viewGroup;
+    const nextViewGroup = componentData.viewGroup;
+
+    return (previousUrl === nextUrl && !previousViewGroup && !nextViewGroup) ? true : false;
+  }
+
+  isSameViewGroup(componentData) {
+    const previousUrl = GenericHelpers.getUrlWithoutHash(
+      componentData.previousNodeValues.viewUrl
+    );
+    const nextUrl = GenericHelpers.getUrlWithoutHash(componentData.viewUrl);
+    const previousUrlOrigin = this.getLocation(previousUrl);
+    const nextUrlOrigin = this.getLocation(nextUrl);
+
+    if (previousUrlOrigin !== nextUrlOrigin) {
+      return false;
+    }
+
+    const previousViewGroup = componentData.previousNodeValues.viewGroup;
+    const nextViewGroup = componentData.viewGroup;
+
+    return (previousViewGroup && nextViewGroup && previousViewGroup === nextViewGroup) ? true : false;
+  }
+
+  isSameUserSettingsGroup(componentData) {
+    const currentGroup = componentData.currentNode && componentData.currentNode.userSettingsGroup;
+    const previousGroup = componentData.previousNodeValues && componentData.previousNodeValues.userSettingsGroup;
+
+    return (currentGroup && previousGroup && currentGroup === previousGroup) ? true : false;
+  }
+
+  canReuseIframe(iframe, componentData) {
+    if (!iframe) {
+      return false;
+    }
+    console.log('isSameViewUrl', this.isSameViewUrl(componentData));
+    console.log('isSameViewGroup', this.isSameViewGroup(componentData));
+    console.log('isSameUserSettingsGroup', this.isSameUserSettingsGroup(componentData));
+    return (this.isSameViewUrl(componentData) || this.isSameViewGroup(componentData)) && this.isSameUserSettingsGroup(componentData);
   }
 
   getLocation(url) {

--- a/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js
+++ b/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js
@@ -131,7 +131,6 @@ export const projectDetailNavStructure = projectId => [
     label: 'User Settings',
     viewUrl: '/sampleapp.html#/projects/' + projectId + '/settings',
     icon: 'settings',
-    isolateView: true,
     userSettingsGroup: 'userAccount',
     testId: 'myTestId'
   },


### PR DESCRIPTION
- Force MF be reloaded while switching to a different `userSettingsGroup` 
- Refactor `canReuseIframe` part at [iframe-helpers.js](core/src/utilities/helpers/iframe-helpers.js)

Fixes #1792 
