### PR TITLE
Make navigateIframe and prepareInternalData functions be async

### DIFF
--- a/core/src/App.html
+++ b/core/src/App.html
@@ -218,9 +218,12 @@
   export let searchResult;
   let featureToggleList;
 
-  const prepareInternalData = config => {
+  const prepareInternalData = async config => {
     const iframeConf = config.iframe.luigi;
     featureToggleList = LuigiFeatureToggles.getActiveFeatureToggleList();
+    const userSettingsGroupName = iframeConf.currentNode && iframeConf.currentNode.userSettingsGroup;
+    const userSettingGroups = await LuigiConfig.readUserSettings();
+    const hasUserSettings = (userSettingsGroupName && typeof userSettingGroups === 'object' && userSettingGroups !== null);
     const internalData = {
       isNavigateBack,
       viewStackSize: preservedViews.length,
@@ -229,7 +232,8 @@
       currentTheme: LuigiTheming.getCurrentTheme(),
       clientPermissions: iframeConf.nextViewUrl
         ? iframeConf.nextClientPermissions
-        : iframeConf.clientPermissions
+        : iframeConf.clientPermissions,
+      userSettings: hasUserSettings ? userSettingGroups[userSettingsGroupName] : null
     };
 
     IframeHelpers.specialIframeTypes
@@ -247,20 +251,6 @@
       return;
     }
 
-    let internal = prepareInternalData(config);
-    const userSettingsGroupName =
-      config.iframe.luigi.currentNode.userSettingsGroup;
-    const userSettingGroups = await LuigiConfig.readUserSettings();
-
-    if (
-      userSettingsGroupName &&
-      typeof userSettingGroups === 'object' &&
-      userSettingGroups !== null
-    ) {
-      const userSettings = userSettingGroups[userSettingsGroupName];
-      internal = { ...internal, userSettings };
-    }
-
     const message = {
       msg: 'luigi.init',
       context: JSON.stringify(
@@ -272,7 +262,7 @@
       pathParams: JSON.stringify(
         Object.assign({}, config.pathParams || pathParams)
       ),
-      internal: JSON.stringify(internal),
+      internal: JSON.stringify(await prepareInternalData(config)),
       authData: AuthHelpers.getStoredAuthData()
     };
 

--- a/core/src/services/iframe.js
+++ b/core/src/services/iframe.js
@@ -197,7 +197,7 @@ class IframeClass {
     return !config.iframe.luigi.initOk;
   }
 
-  navigateIframe(config, component, node) {
+  async navigateIframe(config, component, node) {
     clearTimeout(this.timeoutHandle);
     const componentData = component.get();
     let viewUrl = componentData.viewUrl;
@@ -347,6 +347,8 @@ class IframeClass {
       config.iframe['vg'] = this.canCache(componentData.viewGroup)
         ? componentData.viewGroup
         : undefined;
+      config.iframe.luigi.currentNode = componentData.currentNode;
+      const internalData = await component.prepareInternalData(config);
       const message = {
         msg: 'luigi.navigate',
         viewUrl: viewUrl,
@@ -355,7 +357,7 @@ class IframeClass {
         ),
         nodeParams: JSON.stringify(Object.assign({}, componentData.nodeParams)),
         pathParams: JSON.stringify(Object.assign({}, componentData.pathParams)),
-        internal: JSON.stringify(component.prepareInternalData(config))
+        internal: JSON.stringify(internalData)
       };
 
       const withSync = componentData.isNavigationSyncEnabled;

--- a/core/src/services/iframe.js
+++ b/core/src/services/iframe.js
@@ -154,7 +154,7 @@ class IframeClass {
         console.info(
           'navigate: luigi-client did not respond, using fallback by replacing iframe'
         );
-        this.navigateIframe(config, component, node);
+        await this.navigateIframe(config, component, node);
       }
     }, this.iframeNavFallbackTimeout);
   }

--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -387,7 +387,7 @@ class RoutingClass {
           iContainer.classList.remove('lui-webComponent');
         }
         if (!withoutSync) {
-          Iframe.navigateIframe(config, component, iframeElement);
+          await Iframe.navigateIframe(config, component, iframeElement);
         }
       }
     } catch (err) {

--- a/core/test/services/iframe.spec.js
+++ b/core/test/services/iframe.spec.js
@@ -131,7 +131,7 @@ describe('Iframe', () => {
   });
 
   describe('create new iframe with different viewgroup and dont delete the previous one (cache)', () => {
-    it('navigate', () => {
+    it('navigate', async () => {
       sinon.stub(IframeHelpers, 'getMainIframes').callsFake(() => [
         {
           src: 'http://url.com/app.html!#/prevUrl',
@@ -154,13 +154,13 @@ describe('Iframe', () => {
         currentNode: {}
       });
 
-      Iframe.navigateIframe(config, component, node);
+      await Iframe.navigateIframe(config, component, node);
       assert.equal(node.children.length, 2);
     });
   });
 
   describe('create new iframe and add event listener', () => {
-    it('navigate', () => {
+    it('navigate', async () => {
       const spy = sinon.spy(IframeHelpers, 'sendMessageToIframe');
       sinon.stub(IframeHelpers, 'getMainIframes').callsFake(() => [
         {
@@ -184,7 +184,7 @@ describe('Iframe', () => {
 
       assert.notExists(config.iframe);
 
-      Iframe.navigateIframe(config, component, node);
+      await Iframe.navigateIframe(config, component, node);
       config.iframe.dispatchEvent(new Event('load'));
 
       assert.exists(config.iframe);
@@ -193,7 +193,7 @@ describe('Iframe', () => {
   });
 
   describe('check if luigi respond, if not, callback again to replace the iframe', () => {
-    it('navigate', () => {
+    it('navigate', async () => {
       sinon.stub(IframeHelpers, 'getMainIframes').callsFake(() => [
         {
           src: 'http://url.com/app.html!#/prevUrl',
@@ -217,7 +217,7 @@ describe('Iframe', () => {
         currentNode: {}
       });
       assert.equal(config.iframe.src, 'http://luigi.url.de');
-      Iframe.navigateIframe(config, component, node);
+      await Iframe.navigateIframe(config, component, node);
 
       assert(Iframe.setOkResponseHandler.called, 'setOkResponseHandler call');
       assert.equal(config.iframe.src, 'http://url.com/app.html!#/prevUrl');
@@ -345,7 +345,7 @@ describe('Iframe', () => {
   });
 
   describe('use cached iframe with same viewgroup and change viewUrl', () => {
-    it('navigate', () => {
+    it('navigate', async () => {
       sinon.stub(IframeHelpers, 'getMainIframes').callsFake(() => [
         {
           src: 'http://luigi.url.de',
@@ -377,13 +377,13 @@ describe('Iframe', () => {
       RoutingHelpers.substituteViewUrl.returns('http://luigi.url.de/1m');
 
       assert.equal(config.iframe.luigi.nextViewUrl, 'http://luigi.url.de/2');
-      Iframe.navigateIframe(config, component, node);
+      await Iframe.navigateIframe(config, component, node);
       assert.equal(config.iframe.luigi.nextViewUrl, 'http://luigi.url.de/1m');
     });
   });
 
   describe('using withoutSync whould not trigger iframe fallback', () => {
-    it('navigate', () => {
+    it('navigate', async () => {
       const spy = sinon.spy(console, 'info');
       spy.resetHistory();
 
@@ -411,7 +411,7 @@ describe('Iframe', () => {
         isNavigationSyncEnabled: false
       });
       assert.equal(config.iframe.src, 'http://luigi.url.de');
-      Iframe.navigateIframe(config, component, node);
+      await Iframe.navigateIframe(config, component, node);
       clock.tick(3000);
       assert(spy.notCalled, 'console.info() call should not apply');
       // assert.equal(config.iframe.src, 'http://luigi.url.de');

--- a/test/e2e-test-application/src/app/project/settings/settings.component.ts
+++ b/test/e2e-test-application/src/app/project/settings/settings.component.ts
@@ -11,7 +11,8 @@ import {
   NodeParams,
   uxManager,
   getActiveFeatureToggles,
-  getUserSettings
+  getUserSettings,
+  addContextUpdateListener
 } from '@luigi-project/client';
 import { Subscription } from 'rxjs';
 
@@ -59,6 +60,10 @@ export class SettingsComponent implements OnInit {
       if (!this.cdr['destroyed']) {
         this.cdr.detectChanges();
       }
+    });
+
+    addContextUpdateListener(context => {
+      this.userSettings = getUserSettings();
     });
 
     // We suggest to use a centralized approach of LuigiClient.addContextUpdateListener

--- a/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js
+++ b/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js
@@ -131,7 +131,6 @@ export const projectDetailNavStructure = projectId => [
     label: 'User Settings',
     viewUrl: '/sampleapp.html#/projects/' + projectId + '/settings',
     icon: 'settings',
-    isolateView: true,
     userSettingsGroup: 'userAccount',
     testId: 'myTestId'
   },


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Make `navigateIframe` and `prepareInternalData` functions be asynchronous
- MFs will get corresponding `userSettings` object while switching around different `userSettingGroup`

**Related issue(s)**
Fixes #1797 
