### PR TITLE
Confirmation modal enhancements

### DIFF
--- a/client/src/uxManager.js
+++ b/client/src/uxManager.js
@@ -74,7 +74,7 @@ class UxManager extends LuigiClientBase {
    * @param {Object} settings the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
    * @param {('confirmation'|'success'|'warning'|'error'|'information')} settings.type the content of the modal type. (Optional)
    * @param {string} [settings.header="Confirmation"] the content of the modal header
-   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body
+   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup.
    * @param {string|false} [settings.buttonConfirm="Yes"] the label for the modal confirmation button. If set to `false`, the button will not be shown.
    * @param {string} [settings.buttonDismiss="No"] the label for the modal dismiss button
    * @returns {promise} which is resolved when accepting the confirmation modal and rejected when dismissing it

--- a/client/src/uxManager.js
+++ b/client/src/uxManager.js
@@ -74,7 +74,7 @@ class UxManager extends LuigiClientBase {
    * @param {Object} settings the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
    * @param {('confirmation'|'success'|'warning'|'error'|'information')} settings.type the content of the modal type. (Optional)
    * @param {string} [settings.header="Confirmation"] the content of the modal header
-   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup.
+   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`.
    * @param {string|false} [settings.buttonConfirm="Yes"] the label for the modal confirmation button. If set to `false`, the button will not be shown.
    * @param {string} [settings.buttonDismiss="No"] the label for the modal dismiss button
    * @returns {promise} which is resolved when accepting the confirmation modal and rejected when dismissing it

--- a/core/fundamentalStyleClasses.js
+++ b/core/fundamentalStyleClasses.js
@@ -56,7 +56,7 @@ module.exports = [
   // './node_modules/fundamental-styles/dist/textarea.css',
   //'./node_modules/fundamental-styles/dist/tile.css',
   //'./node_modules/fundamental-styles/dist/time.css',
-  //'./node_modules/fundamental-styles/dist/title.css',
+  './node_modules/fundamental-styles/dist/title.css',
   //'./node_modules/fundamental-styles/dist/token.css',
   //'./node_modules/fundamental-styles/dist/tokenizer.css',
   //'./node_modules/fundamental-styles/dist/toolbar.css',

--- a/core/src/ConfirmationModal.html
+++ b/core/src/ConfirmationModal.html
@@ -54,18 +54,33 @@
     error: 'message-error',
     success: 'message-success'
   };
+  const restoreSanitizedTags = [
+    'i',
+    'b',
+    'br',
+    'mark',
+    'strong',
+    'em',
+    'small',
+    'del'
+  ];
 
   onMount(() => {
     const defaultSettings = {
       icon: iconMapping[settings.type],
       header: LuigiI18N.getTranslation('luigi.confirmationModal.header'),
-      body: EscapingHelpers.sanitizeHtml(
-        LuigiI18N.getTranslation('luigi.confirmationModal.body')
-      ),
+      body: LuigiI18N.getTranslation('luigi.confirmationModal.body'),
       buttonDismiss: LuigiI18N.getTranslation('luigi.button.dismiss'),
       buttonConfirm: LuigiI18N.getTranslation('luigi.button.confirm')
     };
-
+    const sanitizedHtml = EscapingHelpers.sanitizeHtml(settings.body);
+    settings = {
+      ...settings,
+      body: EscapingHelpers.restoreSanitizedTags(
+        sanitizedHtml,
+        restoreSanitizedTags
+      )
+    };
     settings = Object.assign(defaultSettings, settings);
 
     const focusedButton = settings.buttonConfirm

--- a/core/src/ConfirmationModal.html
+++ b/core/src/ConfirmationModal.html
@@ -62,7 +62,10 @@
     'strong',
     'em',
     'small',
-    'del'
+    'del',
+    'ins',
+    'sub',
+    'sup'
   ];
 
   onMount(() => {

--- a/core/src/ConfirmationModal.html
+++ b/core/src/ConfirmationModal.html
@@ -10,7 +10,7 @@
           {#if settings.type}
           <i class="sap-icon--{settings.icon}"></i>
           {/if}
-          <h3 class="fd-title fd-title--h5">{settings.header}</h3>
+          <h2 class="fd-title fd-title--h5">{settings.header}</h2>
         </div>
       </div>
     </header>
@@ -42,6 +42,7 @@
   import { createEventDispatcher, onMount } from 'svelte';
   import { LuigiI18N } from './core-api';
   import { KEYCODE_ESC } from './utilities/keycode.js';
+  import { EscapingHelpers } from './utilities/helpers';
 
   const dispatch = createEventDispatcher();
 
@@ -58,7 +59,9 @@
     const defaultSettings = {
       icon: iconMapping[settings.type],
       header: LuigiI18N.getTranslation('luigi.confirmationModal.header'),
-      body: LuigiI18N.getTranslation('luigi.confirmationModal.body'),
+      body: EscapingHelpers.sanitizeHtml(
+        LuigiI18N.getTranslation('luigi.confirmationModal.body')
+      ),
       buttonDismiss: LuigiI18N.getTranslation('luigi.button.dismiss'),
       buttonConfirm: LuigiI18N.getTranslation('luigi.button.confirm')
     };

--- a/core/src/ConfirmationModal.html
+++ b/core/src/ConfirmationModal.html
@@ -14,7 +14,7 @@
         </div>
       </div>
     </header>
-    <div class="fd-message-box__body">{settings.body}</div>
+    <div class="fd-message-box__body">{@html settings.body}</div>
     <footer class="fd-bar fd-bar--footer fd-message-box__footer">
       <div class="fd-bar__right">
         {#if settings.buttonConfirm !== false}

--- a/core/src/ConfirmationModal.html
+++ b/core/src/ConfirmationModal.html
@@ -54,19 +54,6 @@
     error: 'message-error',
     success: 'message-success'
   };
-  const restoreSanitizedTags = [
-    'i',
-    'b',
-    'br',
-    'mark',
-    'strong',
-    'em',
-    'small',
-    'del',
-    'ins',
-    'sub',
-    'sup'
-  ];
 
   onMount(() => {
     const defaultSettings = {
@@ -76,13 +63,9 @@
       buttonDismiss: LuigiI18N.getTranslation('luigi.button.dismiss'),
       buttonConfirm: LuigiI18N.getTranslation('luigi.button.confirm')
     };
-    const sanitizedHtml = EscapingHelpers.sanitizeHtml(settings.body);
     settings = {
       ...settings,
-      body: EscapingHelpers.restoreSanitizedTags(
-        sanitizedHtml,
-        restoreSanitizedTags
-      )
+      body: EscapingHelpers.sanatizeHtmlExceptTextFormatting(settings.body)
     };
     settings = Object.assign(defaultSettings, settings);
 

--- a/core/src/core-api/ux.js
+++ b/core/src/core-api/ux.js
@@ -76,7 +76,7 @@ class LuigiUX {
    * @param {Object} settings the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
    * @param {('confirmation'|'success'|'warning'|'error'|'information')} settings.type the content of the modal type. (Optional)
    * @param {string} [settings.header="Confirmation"] the content of the modal header
-   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup.
+   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`.
    * @param {string|false} [settings.buttonConfirm="Yes"] the label for the modal confirmation button. If set to `false`, the button will not be shown.
    * @param {string} [settings.buttonDismiss="No"] the label for the modal dismiss button
    * @returns {promise} which is resolved when accepting the confirmation modal and rejected when dismissing it

--- a/core/src/core-api/ux.js
+++ b/core/src/core-api/ux.js
@@ -76,7 +76,7 @@ class LuigiUX {
    * @param {Object} settings the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
    * @param {('confirmation'|'success'|'warning'|'error'|'information')} settings.type the content of the modal type. (Optional)
    * @param {string} [settings.header="Confirmation"] the content of the modal header
-   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body
+   * @param {string} [settings.body="Are you sure you want to do this?"] the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup.
    * @param {string|false} [settings.buttonConfirm="Yes"] the label for the modal confirmation button. If set to `false`, the button will not be shown.
    * @param {string} [settings.buttonDismiss="No"] the label for the modal dismiss button
    * @returns {promise} which is resolved when accepting the confirmation modal and rejected when dismissing it

--- a/core/src/utilities/helpers/escaping-helpers.js
+++ b/core/src/utilities/helpers/escaping-helpers.js
@@ -18,32 +18,49 @@ class EscapingHelpersClass {
       .replace(/&lt;br &gt;/g, '<br>');
   }
 
-  restoreSanitizedTags(text, tags) {
+  restoreSanitizedElements(text) {
     let result = text;
+    const elements = [
+      'i',
+      'b',
+      'br',
+      'mark',
+      'strong',
+      'em',
+      'small',
+      'del',
+      'ins',
+      'sub',
+      'sup'
+    ];
 
-    for (let i = 0; i < tags.length; i++) {
-      const openTag_1 = new RegExp(`&lt;${tags[i]}\/&gt;`, 'g');
-      const openTag_2 = new RegExp(`&lt;${tags[i]} \/&gt;`, 'g');
-      const openTag_3 = new RegExp(`&lt;${tags[i]}&gt;`, 'g');
-      const openTag_4 = new RegExp(`&lt;${tags[i]} &gt;`, 'g');
+    for (let i = 0; i < elements.length; i++) {
+      const openTag_1 = new RegExp(`&lt;${elements[i]}\/&gt;`, 'g');
+      const openTag_2 = new RegExp(`&lt;${elements[i]} \/&gt;`, 'g');
+      const openTag_3 = new RegExp(`&lt;${elements[i]}&gt;`, 'g');
+      const openTag_4 = new RegExp(`&lt;${elements[i]} &gt;`, 'g');
 
-      const closeTag_1 = new RegExp(`&lt;\/${tags[i]}[\/]&gt;`, 'g');
-      const closeTag_2 = new RegExp(`&lt;\/${tags[i]} [\/]&gt;`, 'g');
-      const closeTag_3 = new RegExp(`&lt;[\/]${tags[i]}&gt;`, 'g');
-      const closeTag_4 = new RegExp(`&lt;[\/]${tags[i]} &gt;`, 'g');
+      const closeTag_1 = new RegExp(`&lt;\/${elements[i]}[\/]&gt;`, 'g');
+      const closeTag_2 = new RegExp(`&lt;\/${elements[i]} [\/]&gt;`, 'g');
+      const closeTag_3 = new RegExp(`&lt;[\/]${elements[i]}&gt;`, 'g');
+      const closeTag_4 = new RegExp(`&lt;[\/]${elements[i]} &gt;`, 'g');
 
       result = result
-        .replace(openTag_1, `<${tags[i]}>`)
-        .replace(openTag_2, `<${tags[i]}>`)
-        .replace(openTag_3, `<${tags[i]}>`)
-        .replace(openTag_4, `<${tags[i]}>`)
-        .replace(closeTag_1, `</${tags[i]}>`)
-        .replace(closeTag_2, `</${tags[i]}>`)
-        .replace(closeTag_3, `</${tags[i]}>`)
-        .replace(closeTag_4, `</${tags[i]}>`);
+        .replace(openTag_1, `<${elements[i]}>`)
+        .replace(openTag_2, `<${elements[i]}>`)
+        .replace(openTag_3, `<${elements[i]}>`)
+        .replace(openTag_4, `<${elements[i]}>`)
+        .replace(closeTag_1, `</${elements[i]}>`)
+        .replace(closeTag_2, `</${elements[i]}>`)
+        .replace(closeTag_3, `</${elements[i]}>`)
+        .replace(closeTag_4, `</${elements[i]}>`);
     }
 
     return result;
+  }
+
+  sanatizeHtmlExceptTextFormatting(text) {
+    return this.restoreSanitizedElements(this.sanitizeHtml(text));
   }
 
   sanitizeParam(param) {

--- a/core/src/utilities/helpers/escaping-helpers.js
+++ b/core/src/utilities/helpers/escaping-helpers.js
@@ -18,6 +18,34 @@ class EscapingHelpersClass {
       .replace(/&lt;br &gt;/g, '<br>');
   }
 
+  restoreSanitizedTags(text, tags) {
+    let result = text;
+
+    for (let i = 0; i < tags.length; i++) {
+      const openTag_1 = new RegExp(`&lt;${tags[i]}\/&gt;`, 'g');
+      const openTag_2 = new RegExp(`&lt;${tags[i]} \/&gt;`, 'g');
+      const openTag_3 = new RegExp(`&lt;${tags[i]}&gt;`, 'g');
+      const openTag_4 = new RegExp(`&lt;${tags[i]} &gt;`, 'g');
+
+      const closeTag_1 = new RegExp(`&lt;\/${tags[i]}[\/]&gt;`, 'g');
+      const closeTag_2 = new RegExp(`&lt;\/${tags[i]} [\/]&gt;`, 'g');
+      const closeTag_3 = new RegExp(`&lt;[\/]${tags[i]}&gt;`, 'g');
+      const closeTag_4 = new RegExp(`&lt;[\/]${tags[i]} &gt;`, 'g');
+
+      result = result
+        .replace(openTag_1, `<${tags[i]}>`)
+        .replace(openTag_2, `<${tags[i]}>`)
+        .replace(openTag_3, `<${tags[i]}>`)
+        .replace(openTag_4, `<${tags[i]}>`)
+        .replace(closeTag_1, `</${tags[i]}>`)
+        .replace(closeTag_2, `</${tags[i]}>`)
+        .replace(closeTag_3, `</${tags[i]}>`)
+        .replace(closeTag_4, `</${tags[i]}>`);
+    }
+
+    return result;
+  }
+
   sanitizeParam(param) {
     return String(param)
       .replace(/</g, '&lt;')

--- a/core/test/utilities/helpers/escaping-helpers.spec.js
+++ b/core/test/utilities/helpers/escaping-helpers.spec.js
@@ -18,19 +18,21 @@ describe('Escaping-helpers', () => {
 
   it('restoreSanitizedBrs', () => {
     const text = '&lt;br&gt; &lt;br &gt; &lt;br /&gt; &lt;br/&gt;';
-    const sanitizedHtml = EscapingHelpers.restoreSanitizedBrs(text);
-    assert.equal(sanitizedHtml, '<br> <br> <br> <br>');
+    const restoredHtml = EscapingHelpers.restoreSanitizedBrs(text);
+    assert.equal(restoredHtml, '<br> <br> <br> <br>');
   });
 
-  it('restoreSanitizedTags', () => {
+  it('restoreSanitizedElements', () => {
     const text =
       '&lt;br&gt; &lt;b &gt; &lt;del /&gt; &lt;i/&gt; &lt;strong&gt;';
-    const restoreSanitizedTags = ['br', 'b', 'i', 'del', 'strong'];
-    const sanitizedHtml = EscapingHelpers.restoreSanitizedTags(
-      text,
-      restoreSanitizedTags
-    );
-    assert.equal(sanitizedHtml, '<br> <b> <del> <i> <strong>');
+    const restoredHtml = EscapingHelpers.restoreSanitizedElements(text);
+    assert.equal(restoredHtml, '<br> <b> <del> <i> <strong>');
+  });
+
+  it('sanatizeHtmlExceptTextFormatting', () => {
+    const text = '<br> <b> <del> <i> <strong> <script>';
+    const restoredHtml = EscapingHelpers.sanatizeHtmlExceptTextFormatting(text);
+    assert.equal(restoredHtml, '<br> <b> <del> <i> <strong> &lt;script&gt;');
   });
 
   it('sanitizeParam', () => {

--- a/core/test/utilities/helpers/escaping-helpers.spec.js
+++ b/core/test/utilities/helpers/escaping-helpers.spec.js
@@ -22,6 +22,17 @@ describe('Escaping-helpers', () => {
     assert.equal(sanitizedHtml, '<br> <br> <br> <br>');
   });
 
+  it('restoreSanitizedTags', () => {
+    const text =
+      '&lt;br&gt; &lt;b &gt; &lt;del /&gt; &lt;i/&gt; &lt;strong&gt;';
+    const restoreSanitizedTags = ['br', 'b', 'i', 'del', 'strong'];
+    const sanitizedHtml = EscapingHelpers.restoreSanitizedTags(
+      text,
+      restoreSanitizedTags
+    );
+    assert.equal(sanitizedHtml, '<br> <b> <del> <i> <strong>');
+  });
+
   it('sanitizeParam', () => {
     const param = '<>"\'/';
     const sanitizedParam = EscapingHelpers.sanitizeParam(param);

--- a/docs/luigi-client-api.md
+++ b/docs/luigi-client-api.md
@@ -797,7 +797,7 @@ Shows a confirmation modal.
 -   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
     -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
     -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup. (optional, default `"Are you sure you want to do this?"`)
     -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
     -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 

--- a/docs/luigi-client-api.md
+++ b/docs/luigi-client-api.md
@@ -797,7 +797,7 @@ Shows a confirmation modal.
 -   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
     -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
     -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
     -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
     -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 

--- a/docs/luigi-client-api.md
+++ b/docs/luigi-client-api.md
@@ -797,7 +797,7 @@ Shows a confirmation modal.
 -   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
     -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
     -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup. (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
     -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
     -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 

--- a/docs/luigi-core-api.md
+++ b/docs/luigi-core-api.md
@@ -877,7 +877,7 @@ Shows a confirmation modal.
 -   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
     -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
     -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
     -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
     -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 

--- a/docs/luigi-core-api.md
+++ b/docs/luigi-core-api.md
@@ -877,7 +877,7 @@ Shows a confirmation modal.
 -   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
     -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
     -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup. (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
     -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
     -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 

--- a/docs/luigi-core-api.md
+++ b/docs/luigi-core-api.md
@@ -877,7 +877,7 @@ Shows a confirmation modal.
 -   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
     -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
     -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It suppports html formatting elements such as b, strong, i, em, mark, small, del, ins, sub, sup. (optional, default `"Are you sure you want to do this?"`)
     -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
     -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 

--- a/test/e2e-test-application/e2e/tests/1-angular/luigi-client-ux-manager-features.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/luigi-client-ux-manager-features.spec.js
@@ -75,6 +75,12 @@ describe('Luigi Client ux manager features', () => {
       cy.get('[data-testid=luigi-confirmation-modal]').should('be.visible');
       cy.get('.sap-icon--message-warning').should('be.visible');
       cy.get('.luigi-modal-confirm').should('not.be.visible');
+      cy.get('.fd-message-box__body')
+        .get('b')
+        .should('be.visible');
+      cy.get('.fd-message-box__body')
+        .get('mark')
+        .should('be.visible');
 
       cy.get('[data-testid=luigi-modal-dismiss]').click();
       cy.get('[data-testid=luigi-confirmation-modal]').should('not.be.visible');

--- a/test/e2e-test-application/src/app/project/project.component.ts
+++ b/test/e2e-test-application/src/app/project/project.component.ts
@@ -165,8 +165,8 @@ export class ProjectComponent implements OnInit, OnDestroy {
     const settings = {
       header: 'Warning',
       type: 'warning',
-      body: `Lorem tipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      body: `Lorem tipsum dolor sit amet, <b>consectetur adipisicing elit</b>, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, <mark>quis nostrud exercitation ullamco</mark> laboris nisi ut aliquip ex ea commodo consequat.
         Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.`,
       buttonConfirm: false,
       buttonDismiss: 'Close'

--- a/test/e2e-test-application/src/app/project/project.component.ts
+++ b/test/e2e-test-application/src/app/project/project.component.ts
@@ -141,8 +141,8 @@ export class ProjectComponent implements OnInit, OnDestroy {
     const settings = {
       // header: 'Modal Header - Luigi modal',
       type: 'confirmation',
-      body: `Lorem tipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+      body: `Lorem <i>tipsum</i> dolor sit amet, <b>consectetur adipisicing elit</b>, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, <br/><br/>quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.`,
       buttonConfirm: 'Confirm',
       buttonDismiss: 'Cancel'
@@ -165,9 +165,9 @@ export class ProjectComponent implements OnInit, OnDestroy {
     const settings = {
       header: 'Warning',
       type: 'warning',
-      body: `Lorem tipsum dolor sit amet, <b>consectetur adipisicing elit</b>, sed do eiusmod tempor incididunt ut labore et dolore magna
-        aliqua. Ut enim ad minim veniam, <mark>quis nostrud exercitation ullamco</mark> laboris nisi ut aliquip ex ea commodo consequat.
-        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.`,
+      body: `<mark>Lorem tipsum dolor sit amet,</mark> <b>consectetur adipisicing elit</b>, sed do eiusmod tempor incididunt ut labore et dolore magna
+        aliqua. Ut enim ad minim veniam, <small>quis nostrud exercitation ullamco</small> laboris nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in <del>reprehenderit</del> in voluptate velit esse cillum dolore eu fugiat nulla pariatur.`,
       buttonConfirm: false,
       buttonDismiss: 'Close'
     };


### PR DESCRIPTION
- Apply FIORI 3 Title styling
- Make confirmation modal's body supports HTML syntax (allow simple text formatting options, e.g. bold, italic, etc)


**Related issue(s)**
Fixes #1896 
