### PR TITLE
Script After Upgrade to node v14 1901

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "test:compatibility": "./scripts/testCompatibility.sh"
+    "test:compatibility": "./scripts/testCompatibility.sh",
+    "change-node-version": "node ./scripts/change.node.version.js"
   },
   "devDependencies": {
     "@starptech/prettyhtml": "^0.10.0",

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -2,7 +2,9 @@ const exec = require('child_process').exec;
 const fs = require('fs');
 const path = require('path');
 
+// This script is used to update package dependencies for all modules in the repository. It is used when updating the local node.js version which results in incompatibilities with existing node_modules.
 
+// return list of all module packages
 const listModules = () => {
   const lernaPath =  path.join(path.resolve(__dirname), '..', 'lerna.json');
   const lernaConfig = JSON.parse(fs.readFileSync(lernaPath).toString());
@@ -44,4 +46,3 @@ const executeModule = async (module) => {
     await executeModule(module);
   }
 })();
-

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -1,0 +1,48 @@
+const exec = require('child_process').exec;
+const fs = require('fs');
+const path = require('path');
+
+
+const listModules = () => {
+  const lernaPath =  path.join(path.resolve(__dirname), '..', 'lerna.json')
+  const lernaConfig = JSON.parse(fs.readFileSync(lernaPath).toString());
+  return lernaConfig.packages;
+}
+
+const executeCommand = async (command) => {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error('exec error: ' + error);
+        reject(stderr);
+        return;
+      }
+      console.log(stdout);
+      resolve(stdout);
+    });
+  });
+}
+
+const executeModule = async (module) => {
+    const pathArray = [path.resolve(__dirname),'..'].concat(module.split('/'));
+    const modulePath =  path.join(...pathArray);
+    const moduleDependencies =   path.join(modulePath, 'node_modules');
+    console.log("Deleting directory "+moduleDependencies);
+    fs.rmdirSync(moduleDependencies, { recursive: true });
+
+    process.chdir( modulePath )
+    console.log("npm install on directory "+modulePath);
+    await executeCommand('npm install');
+};
+
+
+(async () => {
+  let modules = listModules();
+  console.log('Running npm link @angular/cli');
+  await executeCommand('npm link @angular/cli');
+  for (let module of modules){
+    await executeModule(module);
+  }
+})();
+
+

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 
 const listModules = () => {
-  const lernaPath =  path.join(path.resolve(__dirname), '..', 'lerna.json')
+  const lernaPath =  path.join(path.resolve(__dirname), '..', 'lerna.json');
   const lernaConfig = JSON.parse(fs.readFileSync(lernaPath).toString());
   return lernaConfig.packages;
 }
@@ -44,5 +44,4 @@ const executeModule = async (module) => {
     await executeModule(module);
   }
 })();
-
 

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -30,7 +30,7 @@ const executeCommand = async (command) => {
 const executeModule = async (module) => {
     const pathArray = [path.resolve(__dirname),'..'].concat(module.split('/'));
     const modulePath =  path.join(...pathArray);
-    const moduleDependencies =   path.join(modulePath, 'node_modules');
+    const moduleDependencies =  path.join(modulePath, 'node_modules');
     console.log("Deleting directory "+moduleDependencies);
     fs.rmdirSync(moduleDependencies, { recursive: true });
 

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -35,7 +35,7 @@ const executeModule = async (module) => {
     fs.rmdirSync(moduleDependencies, { recursive: true });
 
     process.chdir( modulePath )
-    console.log("npm install on directory "+modulePath);
+    console.log("npm install on directory " + modulePath);
     await executeCommand('npm install');
 };
 

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -28,6 +28,7 @@ const executeCommand = async (command) => {
 
 // takes a module as a parameter and deletes its dependencies and then re-installs them sequentially
 const executeModule = async (module) => {
+    // retrieve path from module
     const pathArray = [path.resolve(__dirname),'..'].concat(module.split('/'));
     const modulePath =  path.join(...pathArray);
     const moduleDependencies =  path.join(modulePath, 'node_modules');

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -26,6 +26,7 @@ const executeCommand = async (command) => {
   });
 }
 
+// takes a module as a parameter and deletes its dependencies and then re-installs them sequentially
 const executeModule = async (module) => {
     const pathArray = [path.resolve(__dirname),'..'].concat(module.split('/'));
     const modulePath =  path.join(...pathArray);

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -11,6 +11,7 @@ const listModules = () => {
   return lernaConfig.packages;
 }
 
+// helper async function used to execute our 'npm' commands  
 const executeCommand = async (command) => {
   return new Promise((resolve, reject) => {
     exec(command, (error, stdout, stderr) => {

--- a/scripts/change.node.version.js
+++ b/scripts/change.node.version.js
@@ -31,7 +31,7 @@ const executeModule = async (module) => {
     const pathArray = [path.resolve(__dirname),'..'].concat(module.split('/'));
     const modulePath =  path.join(...pathArray);
     const moduleDependencies =  path.join(modulePath, 'node_modules');
-    console.log("Deleting directory "+moduleDependencies);
+    console.log("Deleting directory " + moduleDependencies);
     fs.rmdirSync(moduleDependencies, { recursive: true });
 
     process.chdir( modulePath )

--- a/test/e2e-test-application/externalMf/package-lock.json
+++ b/test/e2e-test-application/externalMf/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@luigi-project/client": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@luigi-project/client/-/client-1.10.0.tgz",
+      "integrity": "sha512-0cWPBwaAzkIT8+D/G9v+ue3QuJiIQw4srd8mpTmTHUWTTcYH9DauGRe6n1urD9LpSgJScfujSKCZj9wNX+NbeQ=="
+    },
     "fundamental-styles": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.10.0.tgz",


### PR DESCRIPTION
**Result:**
After changing node version, you would need to run the following command to update and link all the respective packages:
`npm run change-node-version`

**Explanation:**
Internally the script (node ./scripts/change.node.version.js) will:
1) Run `npm link @angular/cli`
2) Delete all node_modules dir
3) For all the modules, it will run `npm install`

 Resolves #1901
