### PR TITLE
Add warning if both virtualTree and children nodes are defined 

### DIFF
--- a/core/src/navigation/services/navigation.js
+++ b/core/src/navigation/services/navigation.js
@@ -290,6 +290,11 @@ class NavigationClass {
         _virtualViewUrl
       });
 
+      if (node.children) {
+        console.warn(
+          'Found both virtualTree and children nodes defined on a navigation node. \nChildren nodes are redundant and ignored when virtualTree is enabled. \nPlease refer to documentation'
+        );
+      }
       node.children = [newChild];
     }
   }


### PR DESCRIPTION
Fixes #1823 

**Description**
- Defining children when `virtualTree` enabled does not break the navigation (since when virtualTree is enabled we always ([(re)assign the new virtually built children](https://github.com/SAP/luigi/blob/master/core/src/navigation/services/navigation.js#L293)) it is nonetheless a mis-configuration that can create confusion.

**Solution**
- This small PR adds a warning in case virtualTree and children nodes are defined at the same time, thus mitigating potential confusions. 
