### PR TITLE
Bugfix: make custom popovers occupy full viewport on mobile screens (My Messages, My Projects popovers)

### DIFF
--- a/core/src/App.html
+++ b/core/src/App.html
@@ -1821,15 +1821,6 @@
         left: $leftNavWidthCollapsed;
       }
     }
-
-    :global(.fd-dialog, .fd-message-box) {
-      &__content {
-        &:not(.fd-dialog__content--mobile, .fd-message-box__content--mobile) {
-          max-width: 90%;
-          min-width: 90%;
-        }
-      }
-    }
   }
 
   :global(html.luigi-app-in-custom-container) {


### PR DESCRIPTION
Fixes #1899 