### PR TITLE
Fix 'disabled loadingIndicator' bug when opening in modal

### DIFF
--- a/core/src/Modal.html
+++ b/core/src/Modal.html
@@ -147,6 +147,9 @@
         });
         wcCreated = true;
       } else {
+        showLoadingIndicator = nodeObject.loadingIndicator
+          ? nodeObject.loadingIndicator.enabled
+          : true;
         const iframe = await createIframeModal(nodeObject.viewUrl, {
           context: pathData.context,
           pathParams: pathData.pathParams,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
-  When opening a mf in a modal, the **loadingIndicator.enabled** value is ignored. The following: 
   ```
   loadingIndicator: {
      enabled: false,
    },
   ```
should disable the loading indicator. This works well in other cases except for the modal. 

**Changes proposed in this pull request:**
- The PR issues a small fix to correct the behavior. 


Fixes #1939 