### PR TITLE
Fix undefined bug in virtualTree warning

### DIFF
--- a/core/src/navigation/services/navigation.js
+++ b/core/src/navigation/services/navigation.js
@@ -237,7 +237,8 @@ class NavigationClass {
         _virtualViewUrl
       });
 
-      const isVirtualChildren = node.children ? node.children[0]._virtualTree : false;
+      const isVirtualChildren =
+        Array.isArray(node.children) && node.children.length > 0 ? node.children[0]._virtualTree : false;
       if (node.children && !isVirtualChildren) {
         console.warn(
           'Found both virtualTree and children nodes defined on a navigation node. \nChildren nodes are redundant and ignored when virtualTree is enabled. \nPlease refer to documentation'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Error: 
`navigation.js:220 Error getting nodes children TypeError: Cannot read property '_virtualTree' of undefined`

Changes proposed in this pull request:
- Add check for array and length

Test:
 - Run lerna bundle and copy resulting _public_ bundle build to _node_modules/@luigi-project/core_ of _jukebox-frame_

