### PR TITLE
dispatch hashchange event

### DIFF
--- a/client/src/lifecycleManager.js
+++ b/client/src/lifecycleManager.js
@@ -105,8 +105,12 @@ class LifecycleManager extends LuigiClientBase {
     helpers.addEventListener('luigi.navigate', e => {
       setContext(e.data);
       if (!this.currentContext.internal.isNavigateBack && !this.currentContext.withoutSync) {
+        const previousHash = window.location.hash;
         history.replaceState({ luigiInduced: true }, '', e.data.viewUrl);
         window.dispatchEvent(new PopStateEvent('popstate', { state: 'luiginavigation' }));
+        if (window.location.hash !== previousHash) {
+          window.dispatchEvent(new HashChangeEvent('hashchange'));
+        }
       }
       // pass additional data to context to enable micro frontend developer to act on internal routing change
       if (this.currentContext.withoutSync) {


### PR DESCRIPTION
for viewgroup navigation, also a hashchange event is dispatched (if hash was changed) in order to support ui frameworks whose routers rely on it.