### PR TITLE
route null fix

### DIFF
--- a/core/src/navigation/services/navigation.js
+++ b/core/src/navigation/services/navigation.js
@@ -1,5 +1,6 @@
 // Main methods used to display and handle the navigation.
 // Please consider adding any new methods to 'navigation-helpers' if they don't require anything from this file.
+
 import {
   AsyncHelpers,
   EscapingHelpers,
@@ -7,8 +8,9 @@ import {
   NavigationHelpers,
   RoutingHelpers
 } from '../../utilities/helpers';
-import { NodeDataManagementStorage } from '../../services/node-data-management';
+
 import { LuigiConfig } from '../../core-api';
+import { NodeDataManagementStorage } from '../../services/node-data-management';
 
 class NavigationClass {
   async getNavigationPath(rootNavProviderPromise, path = '') {
@@ -72,7 +74,7 @@ class NavigationClass {
     if (!NodeDataManagementStorage.hasChildren(node)) {
       try {
         children = await AsyncHelpers.getConfigValueFromObjectAsync(node, 'children', context || node.context);
-        if (children === undefined) {
+        if (children === undefined || children === null) {
           children = [];
         }
         children =


### PR DESCRIPTION
**Description**
  If my child route contains children with path params and Luigi. navigation().navigate() method to navigate from child micro front end to another route in child micro frontend. Navigation js is failing due to children is null in the getChildren method of Navigation js in Luigi core.
example 
` navigation: {
    nodes: [
      {
        pathSegment: 'admin',
        label: 'Admin',
        viewUrl: 'https://example.com/',
        children: [
          {
            pathSegment: ':id',
            label: 'AdminID',
            viewUrl: 'https://example.com/:id',
            children: [
              {
                pathSegment: ':selectedTab',
                label: 'User Profile',
                 viewUrl: 'https://example.com/:id/:selectedTab',
              }
            ]
          }
        ]
      }
    ]
  }
}
`

Changes proposed in this pull request:
included null check also in getChildren method. 
 `if (children === undefined || children === null) {
          children = [];
  }
`

