### PR TITLE
path-exists fix

### DIFF
--- a/client/src/linkManager.js
+++ b/client/src/linkManager.js
@@ -260,11 +260,11 @@ export class linkManager extends LuigiClientBase {
 
     const pathExistsMsg = {
       msg: 'luigi.navigation.pathExists',
-      data: {
+      data: Object.assign(this.options, {
         id: currentId,
         link: path,
         relative: path[0] !== '/'
-      }
+      })
     };
     helpers.sendPostMessageToLuigiCore(pathExistsMsg);
     return pathExistsPromises[currentId];


### PR DESCRIPTION
When using `LuigiClient.linkManager().pathExists(somePath)`, all linkmanager state data added to the chain has been ignored, e.g. `fromParent(), fromContext(), etc.`
This PR will fix this.