### PR TITLE
Extend intent based navigation

### DIFF
--- a/client/luigi-client.d.ts
+++ b/client/luigi-client.d.ts
@@ -75,7 +75,7 @@ export declare interface AlertSettings {
   text?: string;
   type: 'info' | 'success' | 'warning' | 'error';
   links?: {
-    [key: string]: { text: string; url?: string, dismissKey?: string };
+    [key: string]: { text: string; url?: string; dismissKey?: string };
   };
   closeAfter?: number;
 }
@@ -309,13 +309,13 @@ export declare interface LinkManager {
   /**
    * Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
    * parameters.
-   * This method internally generates a url of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
-   * input arguments. This then follows a call to the original linkManager.navigate(...) function.
-   * Consequentially the following calls shall have the exact same effect:
+   * This method internally generates a URL of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
+   * input arguments. This then follows a call to the original `linkManager.navigate(...)` function.
+   * Consequently, the following calls shall have the exact same effect:
    * - linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    * - linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
-   * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: <semanticObject>-<action>
-   * @param {Object} params an object representing all the parameters passed, i.e.: {param1: '1', param2: 2, param3: 'value3'}
+   * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: `<semanticObject>-<action>`
+   * @param {Object} params an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`
    * @example
    * LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    */

--- a/client/luigi-client.d.ts
+++ b/client/luigi-client.d.ts
@@ -302,12 +302,22 @@ export declare interface LinkManager {
    * LuigiClient.linkManager().navigate('/settings', null, true) // preserve view
    * LuigiClient.linkManager().navigate('#?intent=Sales-order?id=13') // intent navigation
    */
-  navigate: (
-    path: string,
-    sessionId?: string,
-    preserveView?: boolean,
-    modalSettings?: ModalSettings
-  ) => void;
+  navigate: (path: string, sessionId?: string, preserveView?: boolean, modalSettings?: ModalSettings) => void;
+
+  /**
+   * Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
+   * parameters.
+   * This method internally generates a url of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
+   * input arguments. This then follows a call to the original linkManager.navigate(...) function.
+   * Consequentially the following calls shall have the exact same effect:
+   * - linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+   * - linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
+   * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: <semanticObject>-<action>
+   * @param {Object} params an object representing all the parameters passed, i.e.: {param1: '1', param2: 2, param3: 'value3'}
+   * @example
+   * LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+   */
+  navigateToIntent: (semanticSlug: string, params: Object) => void;
 
   /** @lends linkManager */
   /**
@@ -365,10 +375,7 @@ export declare interface LinkManager {
    * @example
    * const splitViewHandle = LuigiClient.linkManager().openAsSplitView('projects/pr1/logs', {title: 'Logs', size: 40, collapsed: true});
    */
-  openAsSplitView: (
-    path: string,
-    splitViewSettings?: SplitViewSettings
-  ) => SplitViewInstance;
+  openAsSplitView: (path: string, splitViewSettings?: SplitViewSettings) => SplitViewInstance;
 
   /**
    * Opens a view in a drawer. You can specify if the drawer has a header, if a backdrop is active in the background and configure the size of the drawer. By default the header is shown. The backdrop is not visible and has to be activated. The size of the drawer is by default set to `s` which means 25% of the micro frontend size. You can also use `l`(75%), `m`(50%) or `xs`(15.5%). Optionally, use it in combination with any of the navigation functions.
@@ -469,12 +476,8 @@ export declare interface StorageManager {
  * @param {Lifecycle~initListenerCallback} initFn the function that is called once Luigi is initialized, receives current context and origin as parameters
  * @memberof Lifecycle
  */
-export function addInitListener(
-  initFn: (context: Context, origin?: string) => void
-): number;
-export type addInitListener = (
-  initFn: (context: Context, origin?: string) => void
-) => number;
+export function addInitListener(initFn: (context: Context, origin?: string) => void): number;
+export type addInitListener = (initFn: (context: Context, origin?: string) => void) => number;
 
 /**
  * Callback of the addInitListener
@@ -495,12 +498,8 @@ export type removeInitListener = (id: number) => boolean;
  * @param {function} contextUpdatedFn the listener function called each time Luigi context changes
  * @memberof Lifecycle
  */
-export function addContextUpdateListener(
-  contextUpdatedFn: (context: Context) => void
-): string;
-export type addContextUpdateListener = (
-  contextUpdatedFn: (context: Context) => void
-) => string;
+export function addContextUpdateListener(contextUpdatedFn: (context: Context) => void): string;
+export type addContextUpdateListener = (contextUpdatedFn: (context: Context) => void) => string;
 
 /**
  * Removes a context update listener.

--- a/client/src/linkManager.js
+++ b/client/src/linkManager.js
@@ -91,9 +91,9 @@ export class linkManager extends LuigiClientBase {
   /**
    * Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
    * parameters.
-   * This method internally generates a url of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
-   * input arguments. This then follows a call to the original linkManager.navigate(...) function.
-   * Consequentially the following calls shall have the exact same effect:
+   * This method internally generates a URL of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
+   * input arguments. This then follows a call to the original `linkManager.navigate(...)` function.
+   * Consequently, the following calls shall have the exact same effect:
    * - linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    * - linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
    * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: <semanticObject>-<action>

--- a/client/src/linkManager.js
+++ b/client/src/linkManager.js
@@ -89,6 +89,37 @@ export class linkManager extends LuigiClientBase {
   }
 
   /**
+   * Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
+   * parameters.
+   * This method internally generates a url of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
+   * input arguments. This then follows a call to the original linkManager.navigate(...) function.
+   * Consequentially the following calls shall have the exact same effect:
+   * - linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+   * - linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
+   * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: <semanticObject>-<action>
+   * @param {Object} params an object representing all the parameters passed, i.e.: {param1: '1', param2: 2, param3: 'value3'}
+   * @example
+   * LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+   */
+  navigateToIntent(semanticSlug, params) {
+    let newPath = '#?intent=';
+    newPath += semanticSlug;
+    if (params) {
+      const paramList = Object.entries(params);
+      // append parameters to the path if any
+      if (paramList.length > 0) {
+        newPath += '?';
+        for (const [key, value] of paramList) {
+          newPath += key + '=' + value + '&';
+        }
+        // trim potential excessive ampersand & at the end
+        newPath = newPath.slice(0, -1);
+      }
+    }
+    this.navigate(newPath);
+  }
+
+  /**
    * Opens a view in a modal. You can specify the modal's title and size. If you don't specify the title, it is the node label. If there is no node label, the title remains empty.  The default size of the modal is `l`, which means 80%. You can also use `m` (60%) and `s` (40%) to set the modal size. Optionally, use it in combination with any of the navigation functions.
    * @memberof linkManager
    * @param {string} path navigation path

--- a/client/src/linkManager.js
+++ b/client/src/linkManager.js
@@ -96,8 +96,8 @@ export class linkManager extends LuigiClientBase {
    * Consequently, the following calls shall have the exact same effect:
    * - linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    * - linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
-   * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: <semanticObject>-<action>
-   * @param {Object} params an object representing all the parameters passed, i.e.: {param1: '1', param2: 2, param3: 'value3'}
+   * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: `<semanticObject>-<action>`
+   * @param {Object} params an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`
    * @example
    * LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    */

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -400,6 +400,9 @@ class RoutingHelpersClass {
    * @param {Object} parameters a list of objects consisting in passed parameters
    */
   resolveDynamicIntentPath(path, parameters) {
+    if (!parameters) {
+      return path;
+    }
     let newPath = path;
     // merge list of objects into one single object for easier iteration
     const mergedParams = Object.assign({}, ...parameters);

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -430,8 +430,8 @@ class RoutingHelpersClass {
    * For both 1. and 2., the following dynamic input path: `/projects/:project/details/:user`
    * is resolved through this method to `/projects/pr2/details/john`
    *
-   * @param {string} path the path containing potential dynamic parameter
-   * @param {Object} parameters a list of objects consisting in passed parameters
+   * @param {string} path the path containing the potential dynamic parameter
+   * @param {Object} parameters a list of objects consisting of passed parameters
    */
   resolveDynamicIntentPath(path, parameters) {
     if (!parameters) {

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -361,6 +361,8 @@ class RoutingHelpersClass {
         }
         realPath = realPath.pathSegment;
         if (intentObject.params) {
+          // resolve dynamic parameters in the path if any
+          realPath = this.resolveDynamicIntentPath(realPath, intentObject.params);
           // get custom node param prefixes if any or default to ~
           let nodeParamPrefix = LuigiConfig.getConfigValue('routing.nodeParamPrefix');
           nodeParamPrefix = nodeParamPrefix ? nodeParamPrefix : '~';
@@ -381,6 +383,36 @@ class RoutingHelpersClass {
       console.warn('No intent mappings are defined in Luigi configuration.');
     }
     return false;
+  }
+
+  /**
+   * This function takes a path which contains dynamic parameters and a list parameters and replaces the dynamic parameters
+   * with the given parameters if any. The input path remains unchanged if the parameters list
+   * does not contain the respective dynamic parameter name.
+   * e.g.:
+   * Assume either of these two calls are made:
+   * 1. linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+   * 2. linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
+   * For both 1. and 2. calls the following dynamic input path: `/projects/:project/details/:user`
+   * is resolved through this method to `/projects/pr2/details/john`
+   *
+   * @param {string} path the path containing potential dynamic parameter
+   * @param {Object} parameters a list of objects consisting in passed parameters
+   */
+  resolveDynamicIntentPath(path, parameters) {
+    let newPath = path;
+    // merge list of objects into one single object for easier iteration
+    const mergedParams = Object.assign({}, ...parameters);
+    for (const [key, value] of Object.entries(mergedParams)) {
+      // regular expression to detect dynamic parameter patterns:
+      // /some/path/:param1/example/:param2/sample
+      // /some/path/example/:param1
+      const regex = new RegExp('/:' + key + '(/|$)', 'g');
+      newPath = newPath.replace(regex, `/${value}/`);
+    }
+    // strip trailing slash
+    newPath = newPath.replace(/\/$/, '');
+    return newPath;
   }
 }
 

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -425,9 +425,9 @@ class RoutingHelpersClass {
    * does not contain the respective dynamic parameter name.
    * e.g.:
    * Assume either of these two calls are made:
-   * 1. linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
-   * 2. linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
-   * For both 1. and 2. calls the following dynamic input path: `/projects/:project/details/:user`
+   * 1. `linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})`
+   * 2. `linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')`
+   * For both 1. and 2., the following dynamic input path: `/projects/:project/details/:user`
    * is resolved through this method to `/projects/pr2/details/john`
    *
    * @param {string} path the path containing potential dynamic parameter

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -10,7 +10,7 @@ import { Navigation } from '../../src/navigation/services/navigation';
 import { NodeDataManagementStorage } from '../../src/services/node-data-management';
 import { Iframe, ViewUrlDecorator } from '../../src/services';
 
-describe('Routing', function () {
+describe('Routing', function() {
   this.retries(1);
 
   let component;
@@ -86,7 +86,7 @@ describe('Routing', function () {
     });
     afterEach(() => {
       global.location = globalLocationRef;
-    })
+    });
 
     it('with path routing, does a browser history replace', async () => {
       // given
@@ -94,18 +94,13 @@ describe('Routing', function () {
       global.location = {
         href: `http://some.url.de${path}`,
         pathname: path
-      }
+      };
 
       // when
       await Routing.navigateTo(path, false);
 
       // then
-      sinon.assert.calledWithExactly(
-        window.history.replaceState,
-        { path },
-        '',
-        '/projects/teams'
-      );
+      sinon.assert.calledWithExactly(window.history.replaceState, { path }, '', '/projects/teams');
       sinon.assert.notCalled(window.history.pushState);
     });
 
@@ -117,10 +112,7 @@ describe('Routing', function () {
       await Routing.navigateTo('/projects');
 
       // then
-      sinon.assert.calledWithExactly(
-        window.dispatchEvent,
-        new CustomEvent('popstate')
-      );
+      sinon.assert.calledWithExactly(window.dispatchEvent, new CustomEvent('popstate'));
     });
   });
 
@@ -140,9 +132,7 @@ describe('Routing', function () {
     });
 
     it('returns intentObject from provided intent link with params', () => {
-      const actual = RoutingHelpers.getIntentObject(
-        '#?intent=Sales-settings?param1=luigi&param2=mario'
-      );
+      const actual = RoutingHelpers.getIntentObject('#?intent=Sales-settings?param1=luigi&param2=mario');
       const expected = {
         semanticObject: 'Sales',
         action: 'settings',
@@ -162,9 +152,7 @@ describe('Routing', function () {
     });
 
     it('falsy intentObject from provided intent link with illegal characters', () => {
-      const actual = RoutingHelpers.getIntentObject(
-        '#?intent=Sales-$et$$tings'
-      );
+      const actual = RoutingHelpers.getIntentObject('#?intent=Sales-$et$$tings');
       assert.isNotOk(actual);
     });
   });
@@ -185,16 +173,12 @@ describe('Routing', function () {
     });
 
     it('checks intent path parsing with illegal characters', () => {
-      const actual = RoutingHelpers.getIntentPath(
-        '#?intent=Sa#les-sett!@ings?param1=luigi&param2=mario'
-      );
+      const actual = RoutingHelpers.getIntentPath('#?intent=Sa#les-sett!@ings?param1=luigi&param2=mario');
       assert.isNotOk(actual);
     });
 
     it('checks intent path parsing with illegal hyphen character', () => {
-      const actual = RoutingHelpers.getIntentPath(
-        '#?intent=Sa-les-sett-ings?param1=luigi&param2=mario'
-      );
+      const actual = RoutingHelpers.getIntentPath('#?intent=Sa-les-sett-ings?param1=luigi&param2=mario');
       assert.isNotOk(actual);
     });
 
@@ -205,18 +189,65 @@ describe('Routing', function () {
     });
 
     it('returns path from provided intent link with params', () => {
-      const actual = RoutingHelpers.getIntentPath(
-        '#?intent=Sales-settings?param1=hello&param2=world'
-      );
+      const actual = RoutingHelpers.getIntentPath('#?intent=Sales-settings?param1=hello&param2=world');
       const expected = '/projects/pr2/settings?~param1=hello&~param2=world';
       assert.equal(actual, expected);
     });
 
     it('returns path from intent link with params and case insensitive start pattern ', () => {
-      const actual = RoutingHelpers.getIntentPath(
-        '#?iNteNT=Sales-settings?param1=hello&param2=world'
-      );
+      const actual = RoutingHelpers.getIntentPath('#?iNteNT=Sales-settings?param1=hello&param2=world');
       const expected = '/projects/pr2/settings?~param1=hello&~param2=world';
+      assert.equal(actual, expected);
+    });
+  });
+
+  describe('resolveDynamicIntentPath()', () => {
+    it('returns resolved dynamic path with single dynamic parameter', () => {
+      const path = '/projects/:id/details';
+      const parameters = [{ id: 123 }];
+      const actual = RoutingHelpers.resolveDynamicIntentPath(path, parameters);
+      const expected = '/projects/123/details';
+      assert.equal(actual, expected);
+    });
+
+    it('returns resolved dynamic path with multiple dynamic parameter', () => {
+      const path = '/projects/:id/details/:componentId/view/:viewId/show';
+      const parameters = [{ id: 123, componentId: 444, viewId: '223' }];
+      const actual = RoutingHelpers.resolveDynamicIntentPath(path, parameters);
+      const expected = '/projects/123/details/444/view/223/show';
+      assert.equal(actual, expected);
+    });
+
+    it('returns resolved dynamic path with similiar named parameters', () => {
+      const path = '/projects/:component/details/:componentId/view/:componentCount/show';
+      const parameters = [{ component: 123 }];
+      const actual = RoutingHelpers.resolveDynamicIntentPath(path, parameters);
+      // check edge case when parameter names stat with same substring
+      const expected = '/projects/123/details/:componentId/view/:componentCount/show';
+      assert.equal(actual, expected);
+    });
+
+    it('input path not changed when there are no parameters defined', () => {
+      const path = '/projects/:component/details/:componentId/view/:componentCount/show';
+      const parameters = undefined;
+      const actual = RoutingHelpers.resolveDynamicIntentPath(path, parameters);
+      const expected = '/projects/:component/details/:componentId/view/:componentCount/show';
+      assert.equal(actual, expected);
+    });
+
+    it('input path not changed when no paramters match dynamic specification', () => {
+      const path = '/projects/:component/details/:componentId/view/:componentCount/show';
+      const parameters = [{ other: 123, param: 343, not: '231', related: 'to dynamic ones' }];
+      const actual = RoutingHelpers.resolveDynamicIntentPath(path, parameters);
+      const expected = '/projects/:component/details/:componentId/view/:componentCount/show';
+      assert.equal(actual, expected);
+    });
+
+    it('returns resolved parameters when there is extra parameters given', () => {
+      const path = '/projects/:other/details/:param/view/:not';
+      const parameters = [{ other: 123, param: 343, not: '231', related: 'to dynamic ones', sample: 'test' }];
+      const actual = RoutingHelpers.resolveDynamicIntentPath(path, parameters);
+      const expected = '/projects/123/details/343/view/231';
       assert.equal(actual, expected);
     });
   });
@@ -249,9 +280,7 @@ describe('Routing', function () {
     });
 
     it('returns path from provided intent link with params', () => {
-      const actual = Routing.getHashPath(
-        '#?intent=Sales-settings?param1=luigi&param2=mario'
-      );
+      const actual = Routing.getHashPath('#?intent=Sales-settings?param1=luigi&param2=mario');
       const expected = '/projects/pr2/settings?~param1=luigi&~param2=mario';
       assert.equal(actual, expected);
     });
@@ -415,9 +444,7 @@ describe('Routing', function () {
         navigateOk: null
       };
       sinon.stub(Routing, 'navigateTo');
-      sinon
-        .stub(GenericHelpers, 'isElementVisible')
-        .callsFake(element => element);
+      sinon.stub(GenericHelpers, 'isElementVisible').callsFake(element => element);
     });
 
     it('should set component data with hash path', async () => {
@@ -427,19 +454,11 @@ describe('Routing', function () {
 
       // when
       sinon.stub(document, 'createElement').callsFake(() => ({ src: null }));
-      await Routing.handleRouteChange(
-        path,
-        component,
-        currentLuigiConfig.navigation.nodes()[0],
-        config
-      );
+      await Routing.handleRouteChange(path, component, currentLuigiConfig.navigation.nodes()[0], config);
 
       // then
       assert.equal(component.get().viewUrl, expectedViewUrl);
-      assert.equal(
-        component.get().hideNav,
-        LuigiConfig.config.settings.hideNavigation
-      );
+      assert.equal(component.get().hideNav, LuigiConfig.config.settings.hideNavigation);
       assert.equal(component.get().showLoadingIndicator, true);
     });
 
@@ -457,12 +476,7 @@ describe('Routing', function () {
 
       // when
       sinon.stub(document, 'createElement').callsFake(() => ({ src: null }));
-      await Routing.handleRouteChange(
-        path,
-        component,
-        currentLuigiConfig.navigation.nodes()[0],
-        config
-      );
+      await Routing.handleRouteChange(path, component, currentLuigiConfig.navigation.nodes()[0], config);
 
       // then
       assert.equal(component.get().viewUrl, expectedViewUrl);
@@ -501,19 +515,11 @@ describe('Routing', function () {
         .returns({ src: null })
         .once();
 
-      await Routing.handleRouteChange(
-        path,
-        componentSaved,
-        currentLuigiConfig.navigation.nodes()[0],
-        config
-      );
+      await Routing.handleRouteChange(path, componentSaved, currentLuigiConfig.navigation.nodes()[0], config);
 
       // then
       assert.equal(componentSaved.get().viewUrl, expectedViewUrl);
-      assert.equal(
-        componentSaved.get().hideNav,
-        LuigiConfig.config.settings.hideNavigation
-      );
+      assert.equal(componentSaved.get().hideNav, LuigiConfig.config.settings.hideNavigation);
 
       assert.equal(componentSaved.get().preservedViews.length, 1);
       docMock.restore();
@@ -529,20 +535,12 @@ describe('Routing', function () {
       // when
       const iframeMock = { src: null };
       sinon.stub(document, 'createElement').callsFake(() => iframeMock);
-      await Routing.handleRouteChange(
-        path,
-        component,
-        currentLuigiConfig.navigation.nodes()[0],
-        config
-      );
+      await Routing.handleRouteChange(path, component, currentLuigiConfig.navigation.nodes()[0], config);
 
       // then
       assert.equal(component.get().viewUrl, expectedViewUrl);
       assert.equal(iframeMock.src, expectedProcessedViewUrl);
-      assert.equal(
-        component.get().hideNav,
-        LuigiConfig.config.settings.hideNavigation
-      );
+      assert.equal(component.get().hideNav, LuigiConfig.config.settings.hideNavigation);
     });
 
     it('should set component data with hash path and clear unused context/node params', async () => {
@@ -554,20 +552,12 @@ describe('Routing', function () {
       // when
       const iframeMock = { src: null };
       sinon.stub(document, 'createElement').callsFake(() => iframeMock);
-      await Routing.handleRouteChange(
-        path,
-        component,
-        currentLuigiConfig.navigation.nodes()[0],
-        config
-      );
+      await Routing.handleRouteChange(path, component, currentLuigiConfig.navigation.nodes()[0], config);
 
       // then
       assert.equal(component.get().viewUrl, expectedViewUrl);
       assert.equal(iframeMock.src, expectedProcessedViewUrl);
-      assert.equal(
-        component.get().hideNav,
-        LuigiConfig.config.settings.hideNavigation
-      );
+      assert.equal(component.get().hideNav, LuigiConfig.config.settings.hideNavigation);
     });
 
     it('should set component data with path param', async () => {
@@ -578,19 +568,11 @@ describe('Routing', function () {
       // when
       const iframeMock = { src: null };
       sinon.stub(document, 'createElement').callsFake(() => iframeMock);
-      await Routing.handleRouteChange(
-        path,
-        component,
-        currentLuigiConfig.navigation.nodes()[0],
-        config
-      );
+      await Routing.handleRouteChange(path, component, currentLuigiConfig.navigation.nodes()[0], config);
 
       // then
       assert.equal(iframeMock.src, expectedViewUrl);
-      assert.equal(
-        component.get().hideNav,
-        window.Luigi.config.settings.hideNavigation
-      );
+      assert.equal(component.get().hideNav, window.Luigi.config.settings.hideNavigation);
     });
 
     it('should set component data with multiple path params', async () => {
@@ -601,19 +583,11 @@ describe('Routing', function () {
       // when
       const iframeMock = { src: null };
       sinon.stub(document, 'createElement').callsFake(() => iframeMock);
-      await Routing.handleRouteChange(
-        path,
-        component,
-        currentLuigiConfig.navigation.nodes()[0],
-        config
-      );
+      await Routing.handleRouteChange(path, component, currentLuigiConfig.navigation.nodes()[0], config);
 
       // then
       assert.equal(iframeMock.src, expectedViewUrl);
-      assert.equal(
-        component.get().hideNav,
-        window.Luigi.config.settings.hideNavigation
-      );
+      assert.equal(component.get().hideNav, window.Luigi.config.settings.hideNavigation);
     });
 
     it('should get DefaultChildNode if viewUrl is not defined', async () => {
@@ -751,12 +725,8 @@ describe('Routing', function () {
     });
 
     it('from intent based link with params', () => {
-      window.location.hash =
-        '#?intent=Sales-settings?param1=luigi&param2=mario';
-      assert.equal(
-        Routing.getModifiedPathname(),
-        '/projects/pr2/settings?~param1=luigi&~param2=mario'
-      );
+      window.location.hash = '#?intent=Sales-settings?param1=luigi&param2=mario';
+      assert.equal(Routing.getModifiedPathname(), '/projects/pr2/settings?~param1=luigi&~param2=mario');
     });
 
     it('from intent based link without params', () => {
@@ -827,7 +797,7 @@ describe('Routing', function () {
 
   describe('showPageNotFoundError()', () => {
     let component = {
-      showAlert: () => { }
+      showAlert: () => {}
     };
     let pathToRedirect = '/go/here';
     let pathToRedirect2 = '/go/there';
@@ -875,10 +845,7 @@ describe('Routing', function () {
       assert.isTrue(isDynamic);
     });
     it('check if it is dynamic Node', () => {
-      let pathParamValue = RoutingHelpers.getDynamicNodeValue(
-        node,
-        nodeData.pathParam
-      );
+      let pathParamValue = RoutingHelpers.getDynamicNodeValue(node, nodeData.pathParam);
       assert.equal(pathParamValue, 'dyn1');
     });
   });
@@ -908,11 +875,7 @@ describe('Routing', function () {
       //then
       sinon.assert.calledWith(Navigation.extractDataFromPath, modalPath);
       sinon.assert.calledOnce(LuigiNavigation.openAsModal);
-      sinon.assert.calledWithExactly(
-        LuigiNavigation.openAsModal,
-        modalPath,
-        modalParams
-      );
+      sinon.assert.calledWithExactly(LuigiNavigation.openAsModal, modalPath, modalParams);
     });
     it('with node setting openNodeInModal', async () => {
       const mockNodeModalSettings = {
@@ -932,11 +895,7 @@ describe('Routing', function () {
       //then
       sinon.assert.calledWith(Navigation.extractDataFromPath, modalPath);
       sinon.assert.calledOnce(LuigiNavigation.openAsModal);
-      sinon.assert.calledWithExactly(
-        LuigiNavigation.openAsModal,
-        modalPath,
-        mockNodeModalSettings.openNodeInModal
-      );
+      sinon.assert.calledWithExactly(LuigiNavigation.openAsModal, modalPath, mockNodeModalSettings.openNodeInModal);
     });
   });
   describe('append and remove modal data from URL using path routing', () => {
@@ -953,9 +912,7 @@ describe('Routing', function () {
       sinon.stub(RoutingHelpers, 'getModalPathFromPath').returns(modalPath);
       sinon.stub(RoutingHelpers, 'getHashQueryParamSeparator').returns('?');
       sinon.stub(RoutingHelpers, 'getModalParamsFromPath').returns(modalParams);
-      sinon
-        .stub(RoutingHelpers, 'getModalViewParamName')
-        .returns(modalParamName);
+      sinon.stub(RoutingHelpers, 'getModalViewParamName').returns(modalParamName);
 
       sinon.stub(Navigation, 'extractDataFromPath').returns({ nodeObject: {} });
 
@@ -997,8 +954,7 @@ describe('Routing', function () {
       global.location = {
         href:
           'http://some.url.de/settings?~luigi=mario&mySpecialModal=%252Fproject-modal&mySpecialModalParams=%7B%22hello%22%3A%22world%22%7D',
-        search:
-          '?~luigi=mario&mySpecialModal=%252Fproject-modal&mySpecialModalParams=%7B%22hello%22%3A%22world%22%7D'
+        search: '?~luigi=mario&mySpecialModal=%252Fproject-modal&mySpecialModalParams=%7B%22hello%22%3A%22world%22%7D'
       };
       window.state = {};
       sinon
@@ -1010,12 +966,7 @@ describe('Routing', function () {
       } catch (error) {
         console.log('error', error);
       }
-      sinon.assert.calledWithExactly(
-        window.history.replaceState,
-        {},
-        '',
-        'http://some.url.de/settings?~luigi=mario'
-      );
+      sinon.assert.calledWithExactly(window.history.replaceState, {}, '', 'http://some.url.de/settings?~luigi=mario');
     });
   });
 
@@ -1033,9 +984,7 @@ describe('Routing', function () {
       sinon.stub(RoutingHelpers, 'getModalPathFromPath').returns(modalPath);
       sinon.stub(RoutingHelpers, 'getHashQueryParamSeparator').returns('?');
       sinon.stub(RoutingHelpers, 'getModalParamsFromPath').returns(modalParams);
-      sinon
-        .stub(RoutingHelpers, 'getModalViewParamName')
-        .returns(modalParamName);
+      sinon.stub(RoutingHelpers, 'getModalViewParamName').returns(modalParamName);
 
       sinon.stub(Navigation, 'extractDataFromPath').returns({ nodeObject: {} });
 
@@ -1090,12 +1039,7 @@ describe('Routing', function () {
       } catch (error) {
         console.log('error', error);
       }
-      sinon.assert.calledWithExactly(
-        window.history.replaceState,
-        {},
-        '',
-        'http://some.url.de/#/settings?~luigi=mario'
-      );
+      sinon.assert.calledWithExactly(window.history.replaceState, {}, '', 'http://some.url.de/#/settings?~luigi=mario');
     });
   });
 
@@ -1111,9 +1055,7 @@ describe('Routing', function () {
     });
 
     it('should leave query params and hash untouched', () => {
-      const path = Routing.normalizePath(
-        'bla/blub/../x/?~a=b&~c=d#/something?~e=f&~g=h'
-      );
+      const path = Routing.normalizePath('bla/blub/../x/?~a=b&~c=d#/something?~e=f&~g=h');
       assert.equal(path, 'bla/x/?~a=b&~c=d#/something?~e=f&~g=h');
     });
   });

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -250,6 +250,14 @@ describe('Routing', function() {
       const expected = '/projects/123/details/343/view/231';
       assert.equal(actual, expected);
     });
+
+    it('input path not changed when array has an empty object', () => {
+      const path = '/projects/:other/details/:param/view/:not';
+      const parameters = [];
+      const actual = RoutingHelpers.resolveDynamicIntentPath(path, parameters);
+      const expected = '/projects/:other/details/:param/view/:not';
+      assert.equal(actual, expected);
+    });
   });
 
   describe('getHashPath()', () => {

--- a/docs/luigi-client-api.md
+++ b/docs/luigi-client-api.md
@@ -17,12 +17,12 @@ meta -->
 
 This document outlines the features provided by the Luigi Client API. It covers these topics:
 
-*   [Lifecycle](#lifecycle) - functions that define the lifecycle of different Luigi elements
-*   [Callbacks](#lifecycleinitlistenercallback) - callback functions for initListener and customMessageListener
-*   [Link manager](#linkmanager) - you can use the linkManager instead of an internal router
-*   [Split view](#splitview) - allows you to open a micro frontend in the lower part of the content area in a "split screen" view
-*   [uxManager](#uxmanager) - functions related to user interface
-*   [storageManager](#storagemanager) - Storage Manager API to store/retrieve objects from Luigi Core local storage
+-   [Lifecycle](#lifecycle) - functions that define the lifecycle of different Luigi elements
+-   [Callbacks](#lifecycleinitlistenercallback) - callback functions for initListener and customMessageListener
+-   [Link manager](#linkmanager) - you can use the linkManager instead of an internal router
+-   [Split view](#splitview) - allows you to open a micro frontend in the lower part of the content area in a "split screen" view
+-   [uxManager](#uxmanager) - functions related to user interface
+-   [storageManager](#storagemanager) - Storage Manager API to store/retrieve objects from Luigi Core local storage
 
 ## API Reference
 
@@ -46,7 +46,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 1.12.0
+-   **since**: 1.12.0
 
 #### luigiClientInit
 
@@ -60,7 +60,7 @@ LuigiClient.luigiClientInit()
 
 **Meta**
 
-*   **since**: 1.12.0
+-   **since**: 1.12.0
 
 #### addInitListener
 
@@ -68,7 +68,7 @@ Registers a listener called with the context object and the Luigi Core domain as
 
 ##### Parameters
 
-*   `initFn` **[Lifecycle~initListenerCallback](#lifecycleinitlistenercallback)** the function that is called once Luigi is initialized, receives current context and origin as parameters
+-   `initFn` **[Lifecycle~initListenerCallback](#lifecycleinitlistenercallback)** the function that is called once Luigi is initialized, receives current context and origin as parameters
 
 ##### Examples
 
@@ -82,7 +82,7 @@ Removes an init listener.
 
 ##### Parameters
 
-*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function.
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function.
 
 ##### Examples
 
@@ -96,7 +96,7 @@ Registers a listener called with the context object when the URL is changed. For
 
 ##### Parameters
 
-*   `contextUpdatedFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time Luigi context changes
+-   `contextUpdatedFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time Luigi context changes
 
 ##### Examples
 
@@ -110,7 +110,7 @@ Removes a context update listener.
 
 ##### Parameters
 
-*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addContextUpdateListener` function
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addContextUpdateListener` function
 
 ##### Examples
 
@@ -123,15 +123,15 @@ LuigiClient.removeContextUpdateListener(updateListenerId)
 Registers a listener called upon micro frontend inactivity. This happens when a new micro frontend gets shown while keeping the old one cached.
 Gets called when:
 
-*   navigating with **preserveView**
-*   navigating from or to a **viewGroup**
+-   navigating with **preserveView**
+-   navigating from or to a **viewGroup**
 
 Does not get called when navigating normally, or when `openAsModal` or `openAsSplitView` are used.
 Once the micro frontend turns back into active state, the `addContextUpdateListener` receives an updated context.
 
 ##### Parameters
 
-*   `inactiveFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time a micro frontend turns into an inactive state
+-   `inactiveFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time a micro frontend turns into an inactive state
 
 ##### Examples
 
@@ -146,7 +146,7 @@ Removes a listener for inactive micro frontends.
 
 ##### Parameters
 
-*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInactiveListener` function
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInactiveListener` function
 
 ##### Examples
 
@@ -160,8 +160,8 @@ Registers a listener called when the micro frontend receives a custom message.
 
 ##### Parameters
 
-*   `customMessageId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the custom message id
-*   `customMessageListener` **[Lifecycle~customMessageListenerCallback](#lifecyclecustommessagelistenercallback)** the function that is called when the micro frontend receives the corresponding event
+-   `customMessageId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the custom message id
+-   `customMessageListener` **[Lifecycle~customMessageListenerCallback](#lifecyclecustommessagelistenercallback)** the function that is called when the micro frontend receives the corresponding event
 
 ##### Examples
 
@@ -171,7 +171,7 @@ const customMsgId = LuigiClient.addCustomMessageListener('myapp.project-updated'
 
 **Meta**
 
-*   **since**: 0.6.2
+-   **since**: 0.6.2
 
 #### removeCustomMessageListener
 
@@ -179,11 +179,11 @@ Removes a custom message listener.
 
 ##### Parameters
 
-*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function
 
 **Meta**
 
-*   **since**: 0.6.2
+-   **since**: 0.6.2
     LuigiClient.removeCustomMessageListener(customMsgId)
 
 #### getToken
@@ -218,7 +218,8 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **deprecated**: This is deprecated.
+-   **deprecated**: This is deprecated.
+
 
 #### getActiveFeatureToggles
 
@@ -234,7 +235,7 @@ Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### getNodeParams
 
@@ -269,7 +270,7 @@ All path parameters in the current navigation path (as defined by the active URL
 const pathParams = LuigiClient.getPathParams()
 ```
 
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** path parameters, where the object property name is the path parameter name without the prefix, and its value is the actual value of the path parameter. For example `  {productId: 1234, ...} `
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** path parameters, where the object property name is the path parameter name without the prefix, and its value is the actual value of the path parameter. For example `{productId: 1234, ...}`
 
 #### getClientPermissions
 
@@ -289,7 +290,7 @@ When the micro frontend is not embedded in the Luigi Core application and there 
 
 ##### Parameters
 
-*   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** target origin
+-   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** target origin
 
 ##### Examples
 
@@ -299,7 +300,7 @@ LuigiClient.setTargetOrigin(window.location.origin)
 
 **Meta**
 
-*   **since**: 0.7.3
+-   **since**: 0.7.3
 
 #### sendCustomMessage
 
@@ -307,10 +308,9 @@ Sends a custom message to the Luigi Core application.
 
 ##### Parameters
 
-*   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the Luigi Core to process it further. This object is set as an input parameter of the custom message listener on the Luigi Core side
-
-    *   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a string containing the message id
-    *   `message.MY_DATA_FIELD` **any** any other message data field
+-   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the Luigi Core to process it further. This object is set as an input parameter of the custom message listener on the Luigi Core side
+    -   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a string containing the message id
+    -   `message.MY_DATA_FIELD` **any** any other message data field
 
 ##### Examples
 
@@ -321,7 +321,7 @@ LuigiClient.sendCustomMessage({id: 'environment.created', data: environmentDataO
 
 **Meta**
 
-*   **since**: 0.6.2
+-   **since**: 0.6.2
 
 #### getUserSettings
 
@@ -337,7 +337,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **since**: 1.7.1
+-   **since**: 1.7.1
 
 ### Lifecycle~initListenerCallback
 
@@ -347,8 +347,8 @@ Type: [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Sta
 
 #### Parameters
 
-*   `context` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** current context data
-*   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Luigi Core URL
+-   `context` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** current context data
+-   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Luigi Core URL
 
 ### Lifecycle~customMessageListenerCallback
 
@@ -358,35 +358,33 @@ Type: [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Sta
 
 #### Parameters
 
-*   `customMessage` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** custom message object
-
-    *   `customMessage.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** message id
-    *   `customMessage.MY_DATA_FIELD` **any** any other message data field
-*   `listenerId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** custom message listener id to be used for unsubscription
+-   `customMessage` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** custom message object
+    -   `customMessage.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** message id
+    -   `customMessage.MY_DATA_FIELD` **any** any other message data field
+-   `listenerId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** custom message listener id to be used for unsubscription
 
 ### linkManager
 
 The Link Manager allows you to navigate to another route. Use it instead of an internal router to:
 
-*   Provide routing inside micro frontends.
-*   Reflect the route.
-*   Keep the navigation state in Luigi.
+-   Provide routing inside micro frontends.
+-   Reflect the route.
+-   Keep the navigation state in Luigi.
 
 #### navigateToIntent
 
 Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
 parameters.
-This method internally generates a url of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
-input arguments. This then follows a call to the original linkManager.navigate(...) function.
-Consequentially the following calls shall have the exact same effect:
+This method internally generates a URL of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given input arguments. This then follows a call to the original `linkManager.navigate(...)` function.
+Conequently the following calls shall have the exact same effect:
 
-*   linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
-*   linkManager().navigate('/#?intent=Sales-settings?project=pr2\&user=john')
+-   `linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})`
+-   `linkManager().navigate('/#?intent=Sales-settings?project=pr2\&user=john')`
 
 ##### Parameters
 
-*   `semanticSlug` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** concatenation of semantic object and action connected with a dash (-), i.e.: <semanticObject>-<action>
-*   `params` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object representing all the parameters passed, i.e.: {param1: '1', param2: 2, param3: 'value3'}
+-   `semanticSlug` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** concatenation of semantic object and action connected with a dash (-), i.e.: `<semanticObject>-<action>`
+-   `params` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`
 
 ##### Examples
 
@@ -409,7 +407,7 @@ LuigiClient.linkManager().withoutSync().fromClosestContext().navigate('settings'
 
 **Meta**
 
-*   **since**: 0.7.7
+-   **since**: 0.7.7
 
 #### navigate
 
@@ -417,23 +415,20 @@ Navigates to the given path in the application hosted by Luigi. It contains eith
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
-*   `sessionId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** current Luigi **sessionId**
-*   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
-*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
-
-    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
-*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
-
-    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** creates split view but leaves it closed initially (optional, default `false`)
-*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
-
-    *   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
-    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
+-   `sessionId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** current Luigi **sessionId**
+-   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
+-   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
+    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
+-   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
+    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** creates split view but leaves it closed initially (optional, default `false`)
+-   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
+    -   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
+    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -450,11 +445,10 @@ Opens a view in a modal. You can specify the modal's title and size. If you don'
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
-*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size (optional, default `{}`)
-
-    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+-   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size (optional, default `{}`)
+    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
 
 ##### Examples
 
@@ -464,18 +458,18 @@ LuigiClient.linkManager().openAsModal('projects/pr1/users', {title:'Users', size
 
 #### openAsSplitView
 
-*   **See**: [splitView](#splitview) for further documentation about the returned instance
+-   **See: [splitView](#splitview) for further documentation about the returned instance
+    **
 
 Opens a view in a split view. You can specify the split view's title and size. If you don't specify the title, it is the node label. If there is no node label, the title remains empty. The default size of the split view is `40`, which means 40% height of the split view.
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
-*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
-
-    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+-   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
+    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
 
 ##### Examples
 
@@ -487,7 +481,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### openAsDrawer
 
@@ -495,12 +489,11 @@ Opens a view in a drawer. You can specify the size of the drawer, whether the dr
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
-*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size. (optional, default `{}`)
-
-    *   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
-    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+-   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size. (optional, default `{}`)
+    -   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
+    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -511,7 +504,7 @@ LuigiClient.linkManager().openAsDrawer('projects/pr1/drawer', {header:{title:'My
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0
 
 #### fromContext
 
@@ -519,7 +512,7 @@ Sets the current navigation context to that of a specific parent node which has 
 
 ##### Parameters
 
-*   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ##### Examples
 
@@ -555,7 +548,7 @@ Returns **[linkManager](#linkmanager)** link manager instance
 
 **Meta**
 
-*   **since**: 1.0.1
+-   **since**: 1.0.1
 
 #### fromParent
 
@@ -571,7 +564,7 @@ Returns **[linkManager](#linkmanager)** link manager instance
 
 **Meta**
 
-*   **since**: 1.0.1
+-   **since**: 1.0.1
 
 #### withParams
 
@@ -579,7 +572,7 @@ Sends node parameters to the route. The parameters are used by the `navigate` fu
 
 ##### Parameters
 
-*   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ##### Examples
 
@@ -598,7 +591,7 @@ Checks if the path you can navigate to exists in the main application. For examp
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
 
 ##### Examples
 
@@ -626,7 +619,7 @@ Discards the active view and navigates back to the last visited view. Works with
 
 ##### Parameters
 
-*   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
+-   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
 
 ##### Examples
 
@@ -637,15 +630,15 @@ LuigiClient.linkManager().goBack(true);
 
 ### splitView
 
-Split view
-Allows to open a micro frontend in a split screen in the lower part of the content area. Open it by calling `const splitViewHandle = LuigiClient.linkManager().openAsSplitView`.
+Split view 
+Allows to open a micro frontend in a split screen in the lower part of the content area. Open it by calling `const splitViewHandle = LuigiClient.linkManager().openAsSplitView`. 
 At a given time, you can open only one split view. It closes automatically when you navigate to a different route.
 When you call `handle.collapse()`, the split view gets destroyed. It recreates when you use `handle.expand()`.
 `openAsSplitView` returns an instance of the split view handle. The functions, actions, and event handlers listed below allow you to control and manage the split view.
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### collapse
 
@@ -659,7 +652,7 @@ splitViewHandle.collapse();
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### expand
 
@@ -673,7 +666,7 @@ splitViewHandle.expand();
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### close
 
@@ -687,7 +680,7 @@ splitViewHandle.close();
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### setSize
 
@@ -695,7 +688,7 @@ Sets the height of the split view
 
 ##### Parameters
 
-*   `value` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** lower height in percent
+-   `value` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** lower height in percent
 
 ##### Examples
 
@@ -705,7 +698,7 @@ splitViewHandle.setSize(60);
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### on
 
@@ -713,8 +706,8 @@ Registers a listener for split view events
 
 ##### Parameters
 
-*   `name` **(`"expand"` | `"collapse"` | `"resize"` | `"close"`)** event name
-*   `callback` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** gets called when this event gets triggered by Luigi
+-   `name` **(`"expand"` \| `"collapse"` \| `"resize"` \| `"close"`)** event name
+-   `callback` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** gets called when this event gets triggered by Luigi
 
 ##### Examples
 
@@ -730,7 +723,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### removeEventListener
 
@@ -738,7 +731,7 @@ Unregisters a split view listener
 
 ##### Parameters
 
-*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** listener id
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** listener id
 
 ##### Examples
 
@@ -748,7 +741,7 @@ splitViewHandle.removeEventListener(listenerId);
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### exists
 
@@ -764,7 +757,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### getSize
 
@@ -780,7 +773,7 @@ Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### isCollapsed
 
@@ -796,7 +789,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### isExpanded
 
@@ -812,7 +805,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 ### uxManager
 
@@ -844,7 +837,7 @@ This method informs the main application that there are unsaved changes in the c
 
 ##### Parameters
 
-*   `isDirty` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indicates if there are any unsaved changes on the current page or in the component
+-   `isDirty` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indicates if there are any unsaved changes on the current page or in the component
 
 #### showConfirmationModal
 
@@ -852,13 +845,12 @@ Shows a confirmation modal.
 
 ##### Parameters
 
-*   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
-
-    *   `settings.type` **(`"confirmation"` | `"success"` | `"warning"` | `"error"` | `"information"`)** the content of the modal type. (Optional)
-    *   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    *   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
-    *   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
-    *   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
+-   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
+    -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
+    -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
+    -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 
 ##### Examples
 
@@ -935,7 +927,7 @@ Sets current locale to the specified one.
 
 ##### Parameters
 
-*   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
+-   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
 
 #### isSplitView
 
@@ -945,7 +937,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### isModal
 
@@ -955,7 +947,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### getCurrentTheme
 
@@ -975,8 +967,8 @@ Stores an item for a specific key.
 
 ##### Parameters
 
-*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key used to identify the value
-*   `value` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** item to store; object must be stringifyable
+-   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key used to identify the value
+-   `value` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** item to store; object must be stringifyable
 
 ##### Examples
 
@@ -984,11 +976,11 @@ Stores an item for a specific key.
 LuigiClient.storageManager().setItem('keyExample','valueExample').then(() => console.log('Value stored'))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>** resolves an empty value when the storage operation is over. It will launch an error if storage is not supported, the value cannot be stringified, or if you are using a Luigi reserved key.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves an empty value when the storage operation is over. It will launch an error if storage is not supported, the value cannot be stringified, or if you are using a Luigi reserved key.
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0
 
 #### getItem
 
@@ -996,7 +988,7 @@ Retrieves an item for a specific key.
 
 ##### Parameters
 
-*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
+-   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
 
 ##### Examples
 
@@ -1004,11 +996,11 @@ Retrieves an item for a specific key.
 LuigiClient.storageManager().getItem('keyExample').then((value) => console.log);
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item retrieved from storage. It will launch an error if storage is not supported.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item retrieved from storage. It will launch an error if storage is not supported.
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0
 
 #### removeItem
 
@@ -1016,7 +1008,7 @@ Removes an item for a specific key.
 
 ##### Parameters
 
-*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
+-   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
 
 ##### Examples
 
@@ -1024,11 +1016,11 @@ Removes an item for a specific key.
 LuigiClient.storageManager().removeItem('keyExample').then((value) => console.log(value + ' just removed')
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item just removed from storage. It will launch an error if storage is not supported or if you are using a Luigi reserved key.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item just removed from storage. It will launch an error if storage is not supported or if you are using a Luigi reserved key.
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0
 
 #### clear
 
@@ -1040,11 +1032,11 @@ Clears all the storage key/values.
 LuigiClient.storageManager().clear().then(() => console.log('storage cleared'))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>** resolves when storage clear is over.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when storage clear is over.
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0
 
 #### has
 
@@ -1052,7 +1044,7 @@ Checks if a key is present in storage.
 
 ##### Parameters
 
-*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key in the storage
+-   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key in the storage
 
 ##### Examples
 
@@ -1060,11 +1052,11 @@ Checks if a key is present in storage.
 LuigiClient.storageManager().has(key).then((present) => console.log('item is present '+present))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)>** `true` if key is present, `false` if it is not
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)>** `true` if key is present, `false` if it is not
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0
 
 #### getAllKeys
 
@@ -1076,8 +1068,8 @@ Gets all the keys used in the storage.
 LuigiClient.storageManager().getAllKeys().then((keys) => console.log('keys are '+keys))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>>** keys currently present in the storage
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>>** keys currently present in the storage
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0

--- a/docs/luigi-client-api.md
+++ b/docs/luigi-client-api.md
@@ -17,12 +17,12 @@ meta -->
 
 This document outlines the features provided by the Luigi Client API. It covers these topics:
 
--   [Lifecycle](#lifecycle) - functions that define the lifecycle of different Luigi elements
--   [Callbacks](#lifecycleinitlistenercallback) - callback functions for initListener and customMessageListener
--   [Link manager](#linkmanager) - you can use the linkManager instead of an internal router
--   [Split view](#splitview) - allows you to open a micro frontend in the lower part of the content area in a "split screen" view
--   [uxManager](#uxmanager) - functions related to user interface
--   [storageManager](#storagemanager) - Storage Manager API to store/retrieve objects from Luigi Core local storage
+*   [Lifecycle](#lifecycle) - functions that define the lifecycle of different Luigi elements
+*   [Callbacks](#lifecycleinitlistenercallback) - callback functions for initListener and customMessageListener
+*   [Link manager](#linkmanager) - you can use the linkManager instead of an internal router
+*   [Split view](#splitview) - allows you to open a micro frontend in the lower part of the content area in a "split screen" view
+*   [uxManager](#uxmanager) - functions related to user interface
+*   [storageManager](#storagemanager) - Storage Manager API to store/retrieve objects from Luigi Core local storage
 
 ## API Reference
 
@@ -46,7 +46,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 1.12.0
+*   **since**: 1.12.0
 
 #### luigiClientInit
 
@@ -60,7 +60,7 @@ LuigiClient.luigiClientInit()
 
 **Meta**
 
--   **since**: 1.12.0
+*   **since**: 1.12.0
 
 #### addInitListener
 
@@ -68,7 +68,7 @@ Registers a listener called with the context object and the Luigi Core domain as
 
 ##### Parameters
 
--   `initFn` **[Lifecycle~initListenerCallback](#lifecycleinitlistenercallback)** the function that is called once Luigi is initialized, receives current context and origin as parameters
+*   `initFn` **[Lifecycle~initListenerCallback](#lifecycleinitlistenercallback)** the function that is called once Luigi is initialized, receives current context and origin as parameters
 
 ##### Examples
 
@@ -82,7 +82,7 @@ Removes an init listener.
 
 ##### Parameters
 
--   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function.
+*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function.
 
 ##### Examples
 
@@ -96,7 +96,7 @@ Registers a listener called with the context object when the URL is changed. For
 
 ##### Parameters
 
--   `contextUpdatedFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time Luigi context changes
+*   `contextUpdatedFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time Luigi context changes
 
 ##### Examples
 
@@ -110,7 +110,7 @@ Removes a context update listener.
 
 ##### Parameters
 
--   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addContextUpdateListener` function
+*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addContextUpdateListener` function
 
 ##### Examples
 
@@ -123,15 +123,15 @@ LuigiClient.removeContextUpdateListener(updateListenerId)
 Registers a listener called upon micro frontend inactivity. This happens when a new micro frontend gets shown while keeping the old one cached.
 Gets called when:
 
--   navigating with **preserveView**
--   navigating from or to a **viewGroup**
+*   navigating with **preserveView**
+*   navigating from or to a **viewGroup**
 
 Does not get called when navigating normally, or when `openAsModal` or `openAsSplitView` are used.
 Once the micro frontend turns back into active state, the `addContextUpdateListener` receives an updated context.
 
 ##### Parameters
 
--   `inactiveFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time a micro frontend turns into an inactive state
+*   `inactiveFn` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** the listener function called each time a micro frontend turns into an inactive state
 
 ##### Examples
 
@@ -146,7 +146,7 @@ Removes a listener for inactive micro frontends.
 
 ##### Parameters
 
--   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInactiveListener` function
+*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInactiveListener` function
 
 ##### Examples
 
@@ -160,8 +160,8 @@ Registers a listener called when the micro frontend receives a custom message.
 
 ##### Parameters
 
--   `customMessageId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the custom message id
--   `customMessageListener` **[Lifecycle~customMessageListenerCallback](#lifecyclecustommessagelistenercallback)** the function that is called when the micro frontend receives the corresponding event
+*   `customMessageId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the custom message id
+*   `customMessageListener` **[Lifecycle~customMessageListenerCallback](#lifecyclecustommessagelistenercallback)** the function that is called when the micro frontend receives the corresponding event
 
 ##### Examples
 
@@ -171,7 +171,7 @@ const customMsgId = LuigiClient.addCustomMessageListener('myapp.project-updated'
 
 **Meta**
 
--   **since**: 0.6.2
+*   **since**: 0.6.2
 
 #### removeCustomMessageListener
 
@@ -179,11 +179,11 @@ Removes a custom message listener.
 
 ##### Parameters
 
--   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function
+*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id that was returned by the `addInitListener` function
 
 **Meta**
 
--   **since**: 0.6.2
+*   **since**: 0.6.2
     LuigiClient.removeCustomMessageListener(customMsgId)
 
 #### getToken
@@ -218,8 +218,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **deprecated**: This is deprecated.
-
+*   **deprecated**: This is deprecated.
 
 #### getActiveFeatureToggles
 
@@ -235,7 +234,7 @@ Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### getNodeParams
 
@@ -270,7 +269,7 @@ All path parameters in the current navigation path (as defined by the active URL
 const pathParams = LuigiClient.getPathParams()
 ```
 
-Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** path parameters, where the object property name is the path parameter name without the prefix, and its value is the actual value of the path parameter. For example `{productId: 1234, ...}`
+Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** path parameters, where the object property name is the path parameter name without the prefix, and its value is the actual value of the path parameter. For example `  {productId: 1234, ...} `
 
 #### getClientPermissions
 
@@ -290,7 +289,7 @@ When the micro frontend is not embedded in the Luigi Core application and there 
 
 ##### Parameters
 
--   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** target origin
+*   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** target origin
 
 ##### Examples
 
@@ -300,7 +299,7 @@ LuigiClient.setTargetOrigin(window.location.origin)
 
 **Meta**
 
--   **since**: 0.7.3
+*   **since**: 0.7.3
 
 #### sendCustomMessage
 
@@ -308,9 +307,10 @@ Sends a custom message to the Luigi Core application.
 
 ##### Parameters
 
--   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the Luigi Core to process it further. This object is set as an input parameter of the custom message listener on the Luigi Core side
-    -   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a string containing the message id
-    -   `message.MY_DATA_FIELD` **any** any other message data field
+*   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the Luigi Core to process it further. This object is set as an input parameter of the custom message listener on the Luigi Core side
+
+    *   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a string containing the message id
+    *   `message.MY_DATA_FIELD` **any** any other message data field
 
 ##### Examples
 
@@ -321,7 +321,7 @@ LuigiClient.sendCustomMessage({id: 'environment.created', data: environmentDataO
 
 **Meta**
 
--   **since**: 0.6.2
+*   **since**: 0.6.2
 
 #### getUserSettings
 
@@ -337,7 +337,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **since**: 1.7.1
+*   **since**: 1.7.1
 
 ### Lifecycle~initListenerCallback
 
@@ -347,8 +347,8 @@ Type: [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Sta
 
 #### Parameters
 
--   `context` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** current context data
--   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Luigi Core URL
+*   `context` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** current context data
+*   `origin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Luigi Core URL
 
 ### Lifecycle~customMessageListenerCallback
 
@@ -358,18 +358,41 @@ Type: [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Sta
 
 #### Parameters
 
--   `customMessage` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** custom message object
-    -   `customMessage.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** message id
-    -   `customMessage.MY_DATA_FIELD` **any** any other message data field
--   `listenerId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** custom message listener id to be used for unsubscription
+*   `customMessage` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** custom message object
+
+    *   `customMessage.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** message id
+    *   `customMessage.MY_DATA_FIELD` **any** any other message data field
+*   `listenerId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** custom message listener id to be used for unsubscription
 
 ### linkManager
 
 The Link Manager allows you to navigate to another route. Use it instead of an internal router to:
 
--   Provide routing inside micro frontends.
--   Reflect the route.
--   Keep the navigation state in Luigi.
+*   Provide routing inside micro frontends.
+*   Reflect the route.
+*   Keep the navigation state in Luigi.
+
+#### navigateToIntent
+
+Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
+parameters.
+This method internally generates a url of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given
+input arguments. This then follows a call to the original linkManager.navigate(...) function.
+Consequentially the following calls shall have the exact same effect:
+
+*   linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+*   linkManager().navigate('/#?intent=Sales-settings?project=pr2\&user=john')
+
+##### Parameters
+
+*   `semanticSlug` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** concatenation of semantic object and action connected with a dash (-), i.e.: <semanticObject>-<action>
+*   `params` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object representing all the parameters passed, i.e.: {param1: '1', param2: 2, param3: 'value3'}
+
+##### Examples
+
+```javascript
+LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+```
 
 #### withoutSync
 
@@ -386,7 +409,7 @@ LuigiClient.linkManager().withoutSync().fromClosestContext().navigate('settings'
 
 **Meta**
 
--   **since**: 0.7.7
+*   **since**: 0.7.7
 
 #### navigate
 
@@ -394,20 +417,23 @@ Navigates to the given path in the application hosted by Luigi. It contains eith
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
--   `sessionId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** current Luigi **sessionId**
--   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
--   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
-    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
--   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
-    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** creates split view but leaves it closed initially (optional, default `false`)
--   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
-    -   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
-    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
+*   `sessionId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** current Luigi **sessionId**
+*   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
+*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
+
+    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
+*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
+
+    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** creates split view but leaves it closed initially (optional, default `false`)
+*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
+
+    *   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
+    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -424,10 +450,11 @@ Opens a view in a modal. You can specify the modal's title and size. If you don'
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
--   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size (optional, default `{}`)
-    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size (optional, default `{}`)
+
+    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
 
 ##### Examples
 
@@ -437,18 +464,18 @@ LuigiClient.linkManager().openAsModal('projects/pr1/users', {title:'Users', size
 
 #### openAsSplitView
 
--   **See: [splitView](#splitview) for further documentation about the returned instance
-    **
+*   **See**: [splitView](#splitview) for further documentation about the returned instance
 
 Opens a view in a split view. You can specify the split view's title and size. If you don't specify the title, it is the node label. If there is no node label, the title remains empty. The default size of the split view is `40`, which means 40% height of the split view.
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
--   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
-    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
+
+    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
 
 ##### Examples
 
@@ -460,7 +487,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### openAsDrawer
 
@@ -468,11 +495,12 @@ Opens a view in a drawer. You can specify the size of the drawer, whether the dr
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
--   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size. (optional, default `{}`)
-    -   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
-    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size. (optional, default `{}`)
+
+    *   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
+    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -483,7 +511,7 @@ LuigiClient.linkManager().openAsDrawer('projects/pr1/drawer', {header:{title:'My
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0
 
 #### fromContext
 
@@ -491,7 +519,7 @@ Sets the current navigation context to that of a specific parent node which has 
 
 ##### Parameters
 
--   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+*   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ##### Examples
 
@@ -527,7 +555,7 @@ Returns **[linkManager](#linkmanager)** link manager instance
 
 **Meta**
 
--   **since**: 1.0.1
+*   **since**: 1.0.1
 
 #### fromParent
 
@@ -543,7 +571,7 @@ Returns **[linkManager](#linkmanager)** link manager instance
 
 **Meta**
 
--   **since**: 1.0.1
+*   **since**: 1.0.1
 
 #### withParams
 
@@ -551,7 +579,7 @@ Sends node parameters to the route. The parameters are used by the `navigate` fu
 
 ##### Parameters
 
--   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+*   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ##### Examples
 
@@ -570,7 +598,7 @@ Checks if the path you can navigate to exists in the main application. For examp
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
 
 ##### Examples
 
@@ -598,7 +626,7 @@ Discards the active view and navigates back to the last visited view. Works with
 
 ##### Parameters
 
--   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
+*   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
 
 ##### Examples
 
@@ -609,15 +637,15 @@ LuigiClient.linkManager().goBack(true);
 
 ### splitView
 
-Split view 
-Allows to open a micro frontend in a split screen in the lower part of the content area. Open it by calling `const splitViewHandle = LuigiClient.linkManager().openAsSplitView`. 
+Split view
+Allows to open a micro frontend in a split screen in the lower part of the content area. Open it by calling `const splitViewHandle = LuigiClient.linkManager().openAsSplitView`.
 At a given time, you can open only one split view. It closes automatically when you navigate to a different route.
 When you call `handle.collapse()`, the split view gets destroyed. It recreates when you use `handle.expand()`.
 `openAsSplitView` returns an instance of the split view handle. The functions, actions, and event handlers listed below allow you to control and manage the split view.
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### collapse
 
@@ -631,7 +659,7 @@ splitViewHandle.collapse();
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### expand
 
@@ -645,7 +673,7 @@ splitViewHandle.expand();
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### close
 
@@ -659,7 +687,7 @@ splitViewHandle.close();
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### setSize
 
@@ -667,7 +695,7 @@ Sets the height of the split view
 
 ##### Parameters
 
--   `value` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** lower height in percent
+*   `value` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** lower height in percent
 
 ##### Examples
 
@@ -677,7 +705,7 @@ splitViewHandle.setSize(60);
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### on
 
@@ -685,8 +713,8 @@ Registers a listener for split view events
 
 ##### Parameters
 
--   `name` **(`"expand"` \| `"collapse"` \| `"resize"` \| `"close"`)** event name
--   `callback` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** gets called when this event gets triggered by Luigi
+*   `name` **(`"expand"` | `"collapse"` | `"resize"` | `"close"`)** event name
+*   `callback` **[function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** gets called when this event gets triggered by Luigi
 
 ##### Examples
 
@@ -702,7 +730,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### removeEventListener
 
@@ -710,7 +738,7 @@ Unregisters a split view listener
 
 ##### Parameters
 
--   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** listener id
+*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** listener id
 
 ##### Examples
 
@@ -720,7 +748,7 @@ splitViewHandle.removeEventListener(listenerId);
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### exists
 
@@ -736,7 +764,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### getSize
 
@@ -752,7 +780,7 @@ Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### isCollapsed
 
@@ -768,7 +796,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### isExpanded
 
@@ -784,7 +812,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 ### uxManager
 
@@ -816,7 +844,7 @@ This method informs the main application that there are unsaved changes in the c
 
 ##### Parameters
 
--   `isDirty` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indicates if there are any unsaved changes on the current page or in the component
+*   `isDirty` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** indicates if there are any unsaved changes on the current page or in the component
 
 #### showConfirmationModal
 
@@ -824,12 +852,13 @@ Shows a confirmation modal.
 
 ##### Parameters
 
--   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
-    -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
-    -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
-    -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
-    -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
+*   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you don't provide any value for any of the fields, a default value is used
+
+    *   `settings.type` **(`"confirmation"` | `"success"` | `"warning"` | `"error"` | `"information"`)** the content of the modal type. (Optional)
+    *   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
+    *   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
+    *   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
+    *   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 
 ##### Examples
 
@@ -858,14 +887,17 @@ Shows an alert.
 
 ##### Parameters
 
--   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings for the alert
-    -   `settings.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the alert. To add a link to the content, you have to set up the link in the `links` object. The key(s) in the `links` object must be used in the text to reference the links, wrapped in curly brackets with no spaces. If you don't specify any text, the alert is not displayed
-    -   `settings.type` **(`"info"` \| `"success"` \| `"warning"` \| `"error"`)** sets the type of alert
-    -   `settings.links` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** provides links data
-        -   `settings.links.LINK_KEY` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** object containing the data for a particular link. To properly render the link in the alert message refer to the description of the **settings.text** parameter
-            -   `settings.links.LINK_KEY.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text which replaces the link identifier in the alert content
-            -   `settings.links.LINK_KEY.url` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** url to navigate when you click the link. Currently, only internal links are supported in the form of relative or absolute paths
-    -   `settings.closeAfter` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** (optional) time in milliseconds that tells Luigi when to close the Alert automatically. If not provided, the Alert will stay on until closed manually. It has to be greater than `100`
+*   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings for the alert
+
+    *   `settings.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the alert. To add a link to the content, you have to set up the link in the `links` object. The key(s) in the `links` object must be used in the text to reference the links, wrapped in curly brackets with no spaces. If you don't specify any text, the alert is not displayed
+    *   `settings.type` **(`"info"` | `"success"` | `"warning"` | `"error"`)** sets the type of alert
+    *   `settings.links` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** provides links data
+
+        *   `settings.links.LINK_KEY` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** object containing the data for a particular link. To properly render the link in the alert message refer to the description of the **settings.text** parameter
+
+            *   `settings.links.LINK_KEY.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text which replaces the link identifier in the alert content
+            *   `settings.links.LINK_KEY.url` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** url to navigate when you click the link. Currently, only internal links are supported in the form of relative or absolute paths
+    *   `settings.closeAfter` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** (optional) time in milliseconds that tells Luigi when to close the Alert automatically. If not provided, the Alert will stay on until closed manually. It has to be greater than `100`
 
 ##### Examples
 
@@ -905,7 +937,7 @@ Sets current locale to the specified one.
 
 ##### Parameters
 
--   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
+*   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
 
 #### isSplitView
 
@@ -915,7 +947,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### isModal
 
@@ -925,7 +957,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### getCurrentTheme
 
@@ -945,8 +977,8 @@ Stores an item for a specific key.
 
 ##### Parameters
 
--   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key used to identify the value
--   `value` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** item to store; object must be stringifyable
+*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key used to identify the value
+*   `value` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** item to store; object must be stringifyable
 
 ##### Examples
 
@@ -954,11 +986,11 @@ Stores an item for a specific key.
 LuigiClient.storageManager().setItem('keyExample','valueExample').then(() => console.log('Value stored'))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves an empty value when the storage operation is over. It will launch an error if storage is not supported, the value cannot be stringified, or if you are using a Luigi reserved key.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>** resolves an empty value when the storage operation is over. It will launch an error if storage is not supported, the value cannot be stringified, or if you are using a Luigi reserved key.
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0
 
 #### getItem
 
@@ -966,7 +998,7 @@ Retrieves an item for a specific key.
 
 ##### Parameters
 
--   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
+*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
 
 ##### Examples
 
@@ -974,11 +1006,11 @@ Retrieves an item for a specific key.
 LuigiClient.storageManager().getItem('keyExample').then((value) => console.log);
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item retrieved from storage. It will launch an error if storage is not supported.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item retrieved from storage. It will launch an error if storage is not supported.
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0
 
 #### removeItem
 
@@ -986,7 +1018,7 @@ Removes an item for a specific key.
 
 ##### Parameters
 
--   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
+*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** used to identify the value
 
 ##### Examples
 
@@ -994,11 +1026,11 @@ Removes an item for a specific key.
 LuigiClient.storageManager().removeItem('keyExample').then((value) => console.log(value + ' just removed')
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item just removed from storage. It will launch an error if storage is not supported or if you are using a Luigi reserved key.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** resolves an item just removed from storage. It will launch an error if storage is not supported or if you are using a Luigi reserved key.
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0
 
 #### clear
 
@@ -1010,11 +1042,11 @@ Clears all the storage key/values.
 LuigiClient.storageManager().clear().then(() => console.log('storage cleared'))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when storage clear is over.
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>** resolves when storage clear is over.
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0
 
 #### has
 
@@ -1022,7 +1054,7 @@ Checks if a key is present in storage.
 
 ##### Parameters
 
--   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key in the storage
+*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key in the storage
 
 ##### Examples
 
@@ -1030,11 +1062,11 @@ Checks if a key is present in storage.
 LuigiClient.storageManager().has(key).then((present) => console.log('item is present '+present))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)>** `true` if key is present, `false` if it is not
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)>** `true` if key is present, `false` if it is not
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0
 
 #### getAllKeys
 
@@ -1046,8 +1078,8 @@ Gets all the keys used in the storage.
 LuigiClient.storageManager().getAllKeys().then((keys) => console.log('keys are '+keys))
 ```
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>>** keys currently present in the storage
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>>** keys currently present in the storage
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0

--- a/docs/luigi-core-api.md
+++ b/docs/luigi-core-api.md
@@ -17,16 +17,16 @@ meta -->
 
 This document outlines the features provided by the Luigi Core API. It covers these topics:
 
-*   [Configuration](#luigi-config) - functions related to Luigi configuration
-*   [Elements](#elements) - functions related to DOM elements
-*   [Authorization](#authorization) - authorization options for Luigi
-*   [Navigation](#luiginavigation) - functions related to Luigi navigation
-*   [Localization](#luigii18n) - options related to language, translation, and localization
-*   [Custom messages](#custommessages) - custom messages between Luigi Core and micro frontends
-*   [UX](#ux) - functions related to Luigi's appearance and user interface
-*   [Global search](#globalsearch) - functions related to Luigi's global search
-*   [Theming](#theming) - functions related to Luigi theming capabilties
-*   [Feature toggles](#featuretoggles) - functions related to Luigi's feature toggle mechanism
+-   [Configuration](#luigi-config) - functions related to Luigi configuration
+-   [Elements](#elements) - functions related to DOM elements
+-   [Authorization](#authorization) - authorization options for Luigi
+-   [Navigation](#luiginavigation) - functions related to Luigi navigation
+-   [Localization](#luigii18n) - options related to language, translation, and localization
+-   [Custom messages](#custommessages) - custom messages between Luigi Core and micro frontends
+-   [UX](#ux) - functions related to Luigi's appearance and user interface
+-   [Global search](#globalsearch) - functions related to Luigi's global search
+-   [Theming](#theming) - functions related to Luigi theming capabilties
+-   [Feature toggles](#featuretoggles) - functions related to Luigi's feature toggle mechanism
 
 ## Luigi Config
 
@@ -40,7 +40,7 @@ Sets the configuration for Luigi initially. Can also be called at a later point 
 
 ##### Parameters
 
-*   `configInput` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the Luigi Core configuration object
+-   `configInput` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the Luigi Core configuration object
 
 ##### Examples
 
@@ -85,7 +85,7 @@ Tells Luigi that the configuration has been changed. Luigi will update the appli
 
 ##### Parameters
 
-*   `scope` **...[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** one or more scope selectors specifying what parts of the configuration were changed. If no scope selector is provided, the whole configuration is considered changed.<p>
+-   `scope` **...[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** one or more scope selectors specifying what parts of the configuration were changed. If no scope selector is provided, the whole configuration is considered changed.<p>
     The supported scope selectors are:
     <p>
     <ul>
@@ -105,7 +105,7 @@ Gets value of the given property on Luigi config object. Target can be a value o
 
 ##### Parameters
 
-*   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
 
 ##### Examples
 
@@ -121,7 +121,7 @@ Function return true if the property value is equal true or 'true'. Otherwise th
 
 ##### Parameters
 
-*   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
 
 ##### Examples
 
@@ -137,8 +137,8 @@ If the value is not a Promise it is wrapped to a Promise so that the returned va
 
 ##### Parameters
 
-*   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
-*   `parameters` **any** optional parameters that are used if the target is a function
+-   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
+-   `parameters` **any** optional parameters that are used if the target is a function
 
 ##### Examples
 
@@ -156,7 +156,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **deprecated**: now located in Luigi.auth() instead of Luigi
+-   **deprecated**: now located in Luigi.auth() instead of Luigi
 
 #### unload
 
@@ -170,7 +170,7 @@ Luigi.unload()
 
 **Meta**
 
-*   **since**: 1.2.2
+-   **since**: 1.2.2
 
 #### readUserSettings
 
@@ -188,7 +188,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 1.7.1
+-   **since**: 1.7.1
 
 #### storeUserSettings
 
@@ -198,8 +198,8 @@ By default, the user settings will be written from the **localStorage**
 
 ##### Parameters
 
-*   `userSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** to store in the storage.
-*   `previousUserSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the previous object from storage.
+-   `userSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** to store in the storage.
+-   `previousUserSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the previous object from storage.
 
 ##### Examples
 
@@ -211,7 +211,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 1.7.1
+-   **since**: 1.7.1
 
 #### reset
 
@@ -225,7 +225,7 @@ Luigi.reset();
 
 **Meta**
 
-*   **since**: 1.14.0
+-   **since**: 1.14.0
 
 ## Luigi.elements()
 
@@ -249,7 +249,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
-*   **since**: 0.6.0
+-   **since**: 0.6.0
 
 #### getShellbar
 
@@ -265,7 +265,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
-*   **since**: 0.4.12
+-   **since**: 0.4.12
 
 #### getShellbarActions
 
@@ -281,7 +281,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
-*   **since**: 0.4.12
+-   **since**: 0.4.12
 
 #### getMicrofrontends
 
@@ -293,11 +293,11 @@ Returns a list of all available micro frontends.
 Luigi.elements().getMicrofrontends();
 ```
 
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<{id: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), active: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean), container: [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element), type: (`"main"` | `"split-view"` | `"modal"`)}>** list of objects defining all micro frontends from the DOM
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;{id: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), active: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean), container: [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element), type: (`"main"` \| `"split-view"` \| `"modal"`)}>** list of objects defining all micro frontends from the DOM
 
 **Meta**
 
-*   **since**: 0.6.2
+-   **since**: 0.6.2
 
 #### getMicrofrontendIframes
 
@@ -309,11 +309,11 @@ Returns all micro frontend iframes including the iframe from the modal if it exi
 Luigi.elements().getMicrofrontendIframes();
 ```
 
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)>** an array of all micro frontend iframes from the DOM
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)>** an array of all micro frontend iframes from the DOM
 
 **Meta**
 
-*   **since**: 0.4.12
+-   **since**: 0.4.12
 
 #### getCurrentMicrofrontendIframe
 
@@ -330,7 +330,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
-*   **since**: 0.4.12
+-   **since**: 0.4.12
 
 ## Luigi.auth()
 
@@ -366,7 +366,7 @@ Luigi.auth().login();
 
 **Meta**
 
-*   **since**: 1.5.0
+-   **since**: 1.5.0
 
 #### logout
 
@@ -381,7 +381,7 @@ Luigi.auth().logout();
 
 **Meta**
 
-*   **since**: 1.5.0
+-   **since**: 1.5.0
 
 ### AuthorizationStore
 
@@ -410,7 +410,7 @@ Retrieves the storage type that is used to store the auth data. To set it, use t
 Luigi.auth().store.getStorageType()
 ```
 
-Returns **(`"localStorage"` | `"sessionStorage"` | `"none"`)** storage type
+Returns **(`"localStorage"` \| `"sessionStorage"` \| `"none"`)** storage type
 
 #### getAuthData
 
@@ -430,7 +430,7 @@ Sets authorization data
 
 ##### Parameters
 
-*   `data` **[AuthData](#authdata)** new auth data object
+-   `data` **[AuthData](#authdata)** new auth data object
 
 ##### Examples
 
@@ -466,10 +466,10 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 
 #### Properties
 
-*   `accessToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** access token value
-*   `accessTokenExpirationDate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** timestamp value
-*   `scope` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** scope, can be empty if it is not required
-*   `idToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** id token, used for renewing authentication
+-   `accessToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** access token value
+-   `accessTokenExpirationDate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** timestamp value
+-   `scope` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** scope, can be empty if it is not required
+-   `idToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** id token, used for renewing authentication
 
 ## Luigi.navigation()
 
@@ -495,22 +495,19 @@ Navigates to the given path in the application. It contains either a full absolu
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
-*   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
-*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
-
-    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
-*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
-
-    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
-*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
-
-    *   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
-    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
+-   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
+-   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
+    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
+-   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
+    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
+-   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
+    -   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
+    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -526,11 +523,10 @@ Opens a view in a modal. You can specify the modal's title and size. If you do n
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
-*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size
-
-    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+-   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size
+    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
 
 ##### Examples
 
@@ -540,18 +536,18 @@ Luigi.navigation().openAsModal('projects/pr1/users', {title:'Users', size:'m'});
 
 #### openAsSplitView
 
-*   **See**: [SplitView Client](https://docs.luigi-project.io/docs/luigi-client-api?section=splitview) for further documentation. These methods from the Client SplitView are also implemented for Luigi Core: `close`, `collapse`, `expand`, `isCollapsed`, `isExpanded`, `exists`
+-   **See: [SplitView Client](https://docs.luigi-project.io/docs/luigi-client-api?section=splitview) for further documentation. These methods from the Client SplitView are also implemented for Luigi Core: `close`, `collapse`, `expand`, `isCollapsed`, `isExpanded`, `exists`
+    **
 
 Opens a view in a split view. You can specify the split view's title and size. If you don't specify the title, it is the node label. If there is no node label, the title remains empty. The default size of the split view is 40, which means 40% height of the split view.
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
-*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
-
-    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+-   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
+    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
 
 ##### Examples
 
@@ -563,7 +559,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **since**: 0.7.6
+-   **since**: 0.7.6
 
 #### openAsDrawer
 
@@ -571,12 +567,11 @@ Opens a view in a drawer. You can specify if the drawer has a header, if a backd
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
-*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
-
-    *   `drawerSettings.header` **any** By default, the header is visible. Title is node label and 'x' is displayed to close the drawer view. The header could also be an object with a `title` attribute to specify an own title for the drawer component.
-    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+-   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
+    -   `drawerSettings.header` **any** By default, the header is visible. Title is node label and 'x' is displayed to close the drawer view. The header could also be an object with a `title` attribute to specify an own title for the drawer component.
+    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -587,7 +582,7 @@ Luigi.navigation().openAsDrawer('projects/pr1/drawer', {header:{title:'My drawer
 
 **Meta**
 
-*   **since**: 1.6.0
+-   **since**: 1.6.0
 
 #### fromContext
 
@@ -595,7 +590,7 @@ Sets the current navigation context to that of a specific parent node which has 
 
 ##### Parameters
 
-*   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+-   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ##### Examples
 
@@ -631,7 +626,7 @@ Returns **linkManager** link manager instance
 
 **Meta**
 
-*   **since**: 1.0.1
+-   **since**: 1.0.1
 
 #### withParams
 
@@ -639,7 +634,7 @@ Sends node parameters to the route. The parameters are used by the `navigate` fu
 
 ##### Parameters
 
-*   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+-   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
 
 ##### Examples
 
@@ -658,7 +653,7 @@ Checks if the path you can navigate to exists in the main application. For examp
 
 ##### Parameters
 
-*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
+-   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
 
 ##### Examples
 
@@ -686,7 +681,7 @@ Discards the active view and navigates back to the last visited view. Works with
 
 ##### Parameters
 
-*   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
+-   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
 
 ##### Examples
 
@@ -711,7 +706,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **since**: 0.5.3
+-   **since**: 0.5.3
 
 #### setCurrentLocale
 
@@ -719,11 +714,11 @@ Sets current locale to the specified one.
 
 ##### Parameters
 
-*   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
+-   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
 
 **Meta**
 
-*   **since**: 0.5.3
+-   **since**: 0.5.3
 
 #### addCurrentLocaleChangeListener
 
@@ -731,13 +726,13 @@ Registers a listener for locale changes.
 
 ##### Parameters
 
-*   `listener` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function called on every locale change with the new locale as argument
+-   `listener` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function called on every locale change with the new locale as argument
 
 Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** listener ID associated with the given listener; use it when removing the listener
 
 **Meta**
 
-*   **since**: 0.5.3
+-   **since**: 0.5.3
 
 #### removeCurrentLocaleChangeListener
 
@@ -745,11 +740,11 @@ Unregisters a listener for locale changes.
 
 ##### Parameters
 
-*   `listenerId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** listener ID associated with the listener to be removed, returned by addCurrentLocaleChangeListener
+-   `listenerId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** listener ID associated with the listener to be removed, returned by addCurrentLocaleChangeListener
 
 **Meta**
 
-*   **since**: 0.5.3
+-   **since**: 0.5.3
 
 #### getTranslation
 
@@ -759,18 +754,17 @@ Property values for token replacement in the localization key will be taken from
 <!-- add-attribute:class:success -->
 
 > **TIP**: Be aware that this function is not asynchronous and therefore the translation table must be existing already at initialization.
-
-Take a look at our [i18n](i18n.md) section for an implementation suggestion.
+> Take a look at our [i18n](i18n.md) section for an implementation suggestion.
 
 ##### Parameters
 
-*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key to be translated
-*   `interpolations` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** objects with properties that will be used for token replacements in the localization key (optional, default `undefined`)
-*   `locale` **locale** optional locale to get the translation for; default is the current locale (optional, default `undefined`)
+-   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key to be translated
+-   `interpolations` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** objects with properties that will be used for token replacements in the localization key (optional, default `undefined`)
+-   `locale` **locale** optional locale to get the translation for; default is the current locale (optional, default `undefined`)
 
 **Meta**
 
-*   **since**: 0.5.3
+-   **since**: 0.5.3
 
 ## Luigi.customMessages()
 
@@ -786,10 +780,9 @@ Sends a custom message to all opened micro frontends.
 
 ##### Parameters
 
-*   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side.
-
-    *   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id of the message
-    *   `message.MY_DATA_FIELD` **any** any other message data field
+-   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side.
+    -   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id of the message
+    -   `message.MY_DATA_FIELD` **any** any other message data field
 
 ##### Examples
 
@@ -803,7 +796,7 @@ Luigi.customMessages().sendToAll({
 
 **Meta**
 
-*   **since**: 0.6.2
+-   **since**: 0.6.2
 
 #### send
 
@@ -812,11 +805,10 @@ Use Luigi.elements().getMicrofrontends() to get the iframe id.
 
 ##### Parameters
 
-*   `microfrontendId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the micro frontend
-*   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side
-
-    *   `message.id` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the message
-    *   `message.MY_DATA_FIELD` **any** any other message data field
+-   `microfrontendId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the micro frontend
+-   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side
+    -   `message.id` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the message
+    -   `message.MY_DATA_FIELD` **any** any other message data field
 
 ##### Examples
 
@@ -830,7 +822,7 @@ Luigi.customMessages().send(microfrontend.id, {
 
 **Meta**
 
-*   **since**: 0.6.2
+-   **since**: 0.6.2
 
 ## Luigi.ux()
 
@@ -846,7 +838,7 @@ Hides the app loading indicator.
 
 **Meta**
 
-*   **since**: 0.6.4
+-   **since**: 0.6.4
 
 #### showAlert
 
@@ -889,7 +881,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 0.6.4
+-   **since**: 0.6.4
 
 #### showConfirmationModal
 
@@ -897,13 +889,12 @@ Shows a confirmation modal.
 
 ##### Parameters
 
-*   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
-
-    *   `settings.type` **(`"confirmation"` | `"success"` | `"warning"` | `"error"` | `"information"`)** the content of the modal type. (Optional)
-    *   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    *   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
-    *   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
-    *   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
+-   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
+    -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
+    -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
+    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
+    -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
+    -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 
 ##### Examples
 
@@ -926,7 +917,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 0.6.4
+-   **since**: 0.6.4
 
 #### setDocumentTitle
 
@@ -934,7 +925,7 @@ Set the document title
 
 ##### Parameters
 
-*   `documentTitle` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
+-   `documentTitle` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ##### Examples
 
@@ -944,7 +935,7 @@ Luigi.ux().setDocumentTitle('Luigi');
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### getDocumentTitle
 
@@ -960,7 +951,7 @@ Returns **any** a string, which is displayed in the tab.
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### collapseLeftSideNav
 
@@ -968,11 +959,11 @@ Set the collapsed state of the left side navigation
 
 ##### Parameters
 
-*   `state` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
+-   `state` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 **Meta**
 
-*   **since**: 1.5.0
+-   **since**: 1.5.0
 
 #### openUserSettings
 
@@ -980,7 +971,7 @@ Open user settings dialog
 
 **Meta**
 
-*   **since**: 1.7.1
+-   **since**: 1.7.1
 
 #### closeUserSettings
 
@@ -988,7 +979,7 @@ Close user settings dialog
 
 **Meta**
 
-*   **since**: 1.7.1
+-   **since**: 1.7.1
 
 ## Luigi.globalSearch()
 
@@ -1010,7 +1001,7 @@ Luigi.globalSearch().openSearchField();
 
 **Meta**
 
-*   **since**: 1.3.0
+-   **since**: 1.3.0
 
 #### closeSearchField
 
@@ -1024,7 +1015,7 @@ Luigi.globalSearch().closeSearchField();
 
 **Meta**
 
-*   **since**: 1.3.0
+-   **since**: 1.3.0
 
 #### clearSearchField
 
@@ -1038,7 +1029,7 @@ Luigi.globalSearch().clearSearchField();
 
 **Meta**
 
-*   **since**: 1.3.0
+-   **since**: 1.3.0
 
 #### showSearchResult
 
@@ -1046,7 +1037,7 @@ Opens the global search result. By standard it is a popover.
 
 ##### Parameters
 
-*   `searchResultItems` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)**
+-   `searchResultItems` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
 
 ##### Examples
 
@@ -1065,7 +1056,7 @@ Luigi.globalSearch().showSearchResult([searchResultItem1, searchResultItem2]);
 
 **Meta**
 
-*   **since**: 1.3.0
+-   **since**: 1.3.0
 
 #### closeSearchResult
 
@@ -1079,7 +1070,7 @@ Luigi.globalSearch().closeSearchResult();
 
 **Meta**
 
-*   **since**: 1.3.0
+-   **since**: 1.3.0
 
 #### getSearchString
 
@@ -1093,7 +1084,7 @@ Luigi.globalSearch().getSearchString();
 
 **Meta**
 
-*   **since**: 1.3.0
+-   **since**: 1.3.0
 
 #### setSearchString
 
@@ -1101,7 +1092,7 @@ Sets the value of the search input field.
 
 ##### Parameters
 
-*   `searchString`  search value
+-   `searchString`  search value
 
 ##### Examples
 
@@ -1111,7 +1102,7 @@ Luigi.globalSearch().setSearchString('searchString');
 
 **Meta**
 
-*   **since**: 1.3.0
+-   **since**: 1.3.0
 
 #### setSearchInputPlaceholder
 
@@ -1119,7 +1110,7 @@ Sets the value of the Placeholder search input field.
 
 ##### Parameters
 
-*   `searchString`  search value
+-   `searchString`  search value
 
 ##### Examples
 
@@ -1129,7 +1120,7 @@ Luigi.globalSearch().setSearchInputPlaceholder('HERE input Placeholder');
 
 **Meta**
 
-*   **since**: 1.7.1
+-   **since**: 1.7.1
 
 ## Luigi.theming()
 
@@ -1158,7 +1149,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### setCurrentTheme
 
@@ -1166,7 +1157,7 @@ Sets the current theme id
 
 ##### Parameters
 
-*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** of a theme object
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** of a theme object
 
 ##### Examples
 
@@ -1176,7 +1167,7 @@ Luigi.theming().setCurrentTheme('light')
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### getThemeObject
 
@@ -1184,7 +1175,7 @@ Retrieves a theme object by name.
 
 ##### Parameters
 
-*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a theme id
+-   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a theme id
 
 ##### Examples
 
@@ -1201,7 +1192,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### getCurrentTheme
 
@@ -1217,7 +1208,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### isThemingAvailable
 
@@ -1233,7 +1224,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 ## Luigi.featureToggles()
 
@@ -1249,7 +1240,7 @@ Add a feature toggle to an active feature toggles list
 
 ##### Parameters
 
-*   `featureToggleName`  
+-   `featureToggleName`  
 
 ##### Examples
 
@@ -1259,7 +1250,7 @@ Luigi.featureToggles().setFeatureToggle('featureToggleName');
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### unsetFeatureToggle
 
@@ -1267,7 +1258,7 @@ Remove a feature toggle from the list
 
 ##### Parameters
 
-*   `featureToggleName`  
+-   `featureToggleName`  
 
 ##### Examples
 
@@ -1277,7 +1268,7 @@ Luigi.featureToggles().unsetFeatureToggle('featureToggleName');
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0
 
 #### getActiveFeatureToggleList
 
@@ -1293,4 +1284,4 @@ Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 **Meta**
 
-*   **since**: 1.4.0
+-   **since**: 1.4.0

--- a/docs/luigi-core-api.md
+++ b/docs/luigi-core-api.md
@@ -17,16 +17,16 @@ meta -->
 
 This document outlines the features provided by the Luigi Core API. It covers these topics:
 
--   [Configuration](#luigi-config) - functions related to Luigi configuration
--   [Elements](#elements) - functions related to DOM elements
--   [Authorization](#authorization) - authorization options for Luigi
--   [Navigation](#luiginavigation) - functions related to Luigi navigation
--   [Localization](#luigii18n) - options related to language, translation, and localization
--   [Custom messages](#custommessages) - custom messages between Luigi Core and micro frontends
--   [UX](#ux) - functions related to Luigi's appearance and user interface
--   [Global search](#globalsearch) - functions related to Luigi's global search
--   [Theming](#theming) - functions related to Luigi theming capabilties
--   [Feature toggles](#featuretoggles) - functions related to Luigi's feature toggle mechanism
+*   [Configuration](#luigi-config) - functions related to Luigi configuration
+*   [Elements](#elements) - functions related to DOM elements
+*   [Authorization](#authorization) - authorization options for Luigi
+*   [Navigation](#luiginavigation) - functions related to Luigi navigation
+*   [Localization](#luigii18n) - options related to language, translation, and localization
+*   [Custom messages](#custommessages) - custom messages between Luigi Core and micro frontends
+*   [UX](#ux) - functions related to Luigi's appearance and user interface
+*   [Global search](#globalsearch) - functions related to Luigi's global search
+*   [Theming](#theming) - functions related to Luigi theming capabilties
+*   [Feature toggles](#featuretoggles) - functions related to Luigi's feature toggle mechanism
 
 ## Luigi Config
 
@@ -40,7 +40,7 @@ Sets the configuration for Luigi initially. Can also be called at a later point 
 
 ##### Parameters
 
--   `configInput` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the Luigi Core configuration object
+*   `configInput` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the Luigi Core configuration object
 
 ##### Examples
 
@@ -85,7 +85,7 @@ Tells Luigi that the configuration has been changed. Luigi will update the appli
 
 ##### Parameters
 
--   `scope` **...[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** one or more scope selectors specifying what parts of the configuration were changed. If no scope selector is provided, the whole configuration is considered changed.<p>
+*   `scope` **...[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** one or more scope selectors specifying what parts of the configuration were changed. If no scope selector is provided, the whole configuration is considered changed.<p>
     The supported scope selectors are:
     <p>
     <ul>
@@ -105,7 +105,7 @@ Gets value of the given property on Luigi config object. Target can be a value o
 
 ##### Parameters
 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
+*   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
 
 ##### Examples
 
@@ -121,7 +121,7 @@ Function return true if the property value is equal true or 'true'. Otherwise th
 
 ##### Parameters
 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
+*   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
 
 ##### Examples
 
@@ -137,8 +137,8 @@ If the value is not a Promise it is wrapped to a Promise so that the returned va
 
 ##### Parameters
 
--   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
--   `parameters` **any** optional parameters that are used if the target is a function
+*   `property` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the object traversal path
+*   `parameters` **any** optional parameters that are used if the target is a function
 
 ##### Examples
 
@@ -156,7 +156,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **deprecated**: now located in Luigi.auth() instead of Luigi
+*   **deprecated**: now located in Luigi.auth() instead of Luigi
 
 #### unload
 
@@ -170,7 +170,7 @@ Luigi.unload()
 
 **Meta**
 
--   **since**: 1.2.2
+*   **since**: 1.2.2
 
 #### readUserSettings
 
@@ -188,7 +188,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 1.7.1
+*   **since**: 1.7.1
 
 #### storeUserSettings
 
@@ -198,8 +198,8 @@ By default, the user settings will be written from the **localStorage**
 
 ##### Parameters
 
--   `userSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** to store in the storage.
--   `previousUserSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the previous object from storage.
+*   `userSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** to store in the storage.
+*   `previousUserSettingsObj` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the previous object from storage.
 
 ##### Examples
 
@@ -211,7 +211,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 1.7.1
+*   **since**: 1.7.1
 
 #### reset
 
@@ -225,7 +225,7 @@ Luigi.reset();
 
 **Meta**
 
--   **since**: 1.14.0
+*   **since**: 1.14.0
 
 ## Luigi.elements()
 
@@ -249,7 +249,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
--   **since**: 0.6.0
+*   **since**: 0.6.0
 
 #### getShellbar
 
@@ -265,7 +265,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
--   **since**: 0.4.12
+*   **since**: 0.4.12
 
 #### getShellbarActions
 
@@ -281,7 +281,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
--   **since**: 0.4.12
+*   **since**: 0.4.12
 
 #### getMicrofrontends
 
@@ -293,11 +293,11 @@ Returns a list of all available micro frontends.
 Luigi.elements().getMicrofrontends();
 ```
 
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;{id: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), active: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean), container: [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element), type: (`"main"` \| `"split-view"` \| `"modal"`)}>** list of objects defining all micro frontends from the DOM
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<{id: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), active: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean), container: [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element), type: (`"main"` | `"split-view"` | `"modal"`)}>** list of objects defining all micro frontends from the DOM
 
 **Meta**
 
--   **since**: 0.6.2
+*   **since**: 0.6.2
 
 #### getMicrofrontendIframes
 
@@ -309,11 +309,11 @@ Returns all micro frontend iframes including the iframe from the modal if it exi
 Luigi.elements().getMicrofrontendIframes();
 ```
 
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)>** an array of all micro frontend iframes from the DOM
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)>** an array of all micro frontend iframes from the DOM
 
 **Meta**
 
--   **since**: 0.4.12
+*   **since**: 0.4.12
 
 #### getCurrentMicrofrontendIframe
 
@@ -330,7 +330,7 @@ Returns **[HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element)** t
 
 **Meta**
 
--   **since**: 0.4.12
+*   **since**: 0.4.12
 
 ## Luigi.auth()
 
@@ -366,7 +366,7 @@ Luigi.auth().login();
 
 **Meta**
 
--   **since**: 1.5.0
+*   **since**: 1.5.0
 
 #### logout
 
@@ -381,7 +381,7 @@ Luigi.auth().logout();
 
 **Meta**
 
--   **since**: 1.5.0
+*   **since**: 1.5.0
 
 ### AuthorizationStore
 
@@ -410,7 +410,7 @@ Retrieves the storage type that is used to store the auth data. To set it, use t
 Luigi.auth().store.getStorageType()
 ```
 
-Returns **(`"localStorage"` \| `"sessionStorage"` \| `"none"`)** storage type
+Returns **(`"localStorage"` | `"sessionStorage"` | `"none"`)** storage type
 
 #### getAuthData
 
@@ -430,7 +430,7 @@ Sets authorization data
 
 ##### Parameters
 
--   `data` **[AuthData](#authdata)** new auth data object
+*   `data` **[AuthData](#authdata)** new auth data object
 
 ##### Examples
 
@@ -466,10 +466,10 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 
 #### Properties
 
--   `accessToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** access token value
--   `accessTokenExpirationDate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** timestamp value
--   `scope` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** scope, can be empty if it is not required
--   `idToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** id token, used for renewing authentication
+*   `accessToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** access token value
+*   `accessTokenExpirationDate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** timestamp value
+*   `scope` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** scope, can be empty if it is not required
+*   `idToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** id token, used for renewing authentication
 
 ## Luigi.navigation()
 
@@ -495,19 +495,22 @@ Navigates to the given path in the application. It contains either a full absolu
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
--   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
--   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
-    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
--   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
-    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
--   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
-    -   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
-    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path to be navigated to
+*   `preserveView` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** preserve a view by setting it to `true`. It keeps the current view opened in the background and opens the new route in a new frame. Use the [goBack()](#goBack) function to navigate back. You can use this feature across different levels. Preserved views are discarded as soon as you use the standard [navigate()](#navigate) function instead of [goBack()](#goBack)
+*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a modal. Use these settings to configure the modal's title and size
+
+    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
+*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour
+
+    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
+*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
+
+    *   `drawerSettings.header` **any** By default, the header is visible. The default title is the node label, but the header could also be an object with a `title` attribute allowing you to specify your own title.  An 'x' icon is displayed to close the drawer view.
+    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -523,10 +526,11 @@ Opens a view in a modal. You can specify the modal's title and size. If you do n
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
--   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size
-    -   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
-    -   `modalSettings.size` **(`"l"` \| `"m"` \| `"s"`)** size of the modal (optional, default `"l"`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+*   `modalSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a modal. Use these settings to configure the modal's title and size
+
+    *   `modalSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** modal title. By default, it is the node label. If there is no label, it is left empty
+    *   `modalSettings.size` **(`"l"` | `"m"` | `"s"`)** size of the modal (optional, default `"l"`)
 
 ##### Examples
 
@@ -536,18 +540,18 @@ Luigi.navigation().openAsModal('projects/pr1/users', {title:'Users', size:'m'});
 
 #### openAsSplitView
 
--   **See: [SplitView Client](https://docs.luigi-project.io/docs/luigi-client-api?section=splitview) for further documentation. These methods from the Client SplitView are also implemented for Luigi Core: `close`, `collapse`, `expand`, `isCollapsed`, `isExpanded`, `exists`
-    **
+*   **See**: [SplitView Client](https://docs.luigi-project.io/docs/luigi-client-api?section=splitview) for further documentation. These methods from the Client SplitView are also implemented for Luigi Core: `close`, `collapse`, `expand`, `isCollapsed`, `isExpanded`, `exists`
 
 Opens a view in a split view. You can specify the split view's title and size. If you don't specify the title, it is the node label. If there is no node label, the title remains empty. The default size of the split view is 40, which means 40% height of the split view.
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
--   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
-    -   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
-    -   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
-    -   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+*   `splitViewSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** opens a view in a split view. Use these settings to configure the split view's behaviour (optional, default `{}`)
+
+    *   `splitViewSettings.title` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** split view title. By default, it is the node label. If there is no label, it is left empty
+    *   `splitViewSettings.size` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** height of the split view in percent (optional, default `40`)
+    *   `splitViewSettings.collapsed` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** opens split view in collapsed state (optional, default `false`)
 
 ##### Examples
 
@@ -559,7 +563,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **since**: 0.7.6
+*   **since**: 0.7.6
 
 #### openAsDrawer
 
@@ -567,11 +571,12 @@ Opens a view in a drawer. You can specify if the drawer has a header, if a backd
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
--   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
-    -   `drawerSettings.header` **any** By default, the header is visible. Title is node label and 'x' is displayed to close the drawer view. The header could also be an object with a `title` attribute to specify an own title for the drawer component.
-    -   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
-    -   `drawerSettings.size` **(`"l"` \| `"m"` \| `"s"` \| `"xs"`)** size of the drawer (optional, default `"s"`)
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** navigation path
+*   `drawerSettings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** opens a view in a drawer. Use these settings to configure if the drawer has a header, backdrop and size.
+
+    *   `drawerSettings.header` **any** By default, the header is visible. Title is node label and 'x' is displayed to close the drawer view. The header could also be an object with a `title` attribute to specify an own title for the drawer component.
+    *   `drawerSettings.backdrop` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** By default, it is set to `false`. If it is set to `true` the rest of the screen has a backdrop.
+    *   `drawerSettings.size` **(`"l"` | `"m"` | `"s"` | `"xs"`)** size of the drawer (optional, default `"s"`)
 
 ##### Examples
 
@@ -582,7 +587,7 @@ Luigi.navigation().openAsDrawer('projects/pr1/drawer', {header:{title:'My drawer
 
 **Meta**
 
--   **since**: 1.6.0
+*   **since**: 1.6.0
 
 #### fromContext
 
@@ -590,7 +595,7 @@ Sets the current navigation context to that of a specific parent node which has 
 
 ##### Parameters
 
--   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+*   `navigationContext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
 ##### Examples
 
@@ -626,7 +631,7 @@ Returns **linkManager** link manager instance
 
 **Meta**
 
--   **since**: 1.0.1
+*   **since**: 1.0.1
 
 #### withParams
 
@@ -634,7 +639,7 @@ Sends node parameters to the route. The parameters are used by the `navigate` fu
 
 ##### Parameters
 
--   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+*   `nodeParams` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**
 
 ##### Examples
 
@@ -653,7 +658,7 @@ Checks if the path you can navigate to exists in the main application. For examp
 
 ##### Parameters
 
--   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
+*   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** path which existence you want to check
 
 ##### Examples
 
@@ -681,7 +686,7 @@ Discards the active view and navigates back to the last visited view. Works with
 
 ##### Parameters
 
--   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
+*   `goBackValue` **any** data that is passed in the **goBackContext** field to the last visited view when using preserved views
 
 ##### Examples
 
@@ -706,7 +711,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **since**: 0.5.3
+*   **since**: 0.5.3
 
 #### setCurrentLocale
 
@@ -714,11 +719,11 @@ Sets current locale to the specified one.
 
 ##### Parameters
 
--   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
+*   `locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** locale to be set as the current locale
 
 **Meta**
 
--   **since**: 0.5.3
+*   **since**: 0.5.3
 
 #### addCurrentLocaleChangeListener
 
@@ -726,13 +731,13 @@ Registers a listener for locale changes.
 
 ##### Parameters
 
--   `listener` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function called on every locale change with the new locale as argument
+*   `listener` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** function called on every locale change with the new locale as argument
 
 Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** listener ID associated with the given listener; use it when removing the listener
 
 **Meta**
 
--   **since**: 0.5.3
+*   **since**: 0.5.3
 
 #### removeCurrentLocaleChangeListener
 
@@ -740,11 +745,11 @@ Unregisters a listener for locale changes.
 
 ##### Parameters
 
--   `listenerId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** listener ID associated with the listener to be removed, returned by addCurrentLocaleChangeListener
+*   `listenerId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** listener ID associated with the listener to be removed, returned by addCurrentLocaleChangeListener
 
 **Meta**
 
--   **since**: 0.5.3
+*   **since**: 0.5.3
 
 #### getTranslation
 
@@ -754,17 +759,18 @@ Property values for token replacement in the localization key will be taken from
 <!-- add-attribute:class:success -->
 
 > **TIP**: Be aware that this function is not asynchronous and therefore the translation table must be existing already at initialization.
-> Take a look at our [i18n](i18n.md) section for an implementation suggestion.
+
+Take a look at our [i18n](i18n.md) section for an implementation suggestion.
 
 ##### Parameters
 
--   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key to be translated
--   `interpolations` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** objects with properties that will be used for token replacements in the localization key (optional, default `undefined`)
--   `locale` **locale** optional locale to get the translation for; default is the current locale (optional, default `undefined`)
+*   `key` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** key to be translated
+*   `interpolations` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** objects with properties that will be used for token replacements in the localization key (optional, default `undefined`)
+*   `locale` **locale** optional locale to get the translation for; default is the current locale (optional, default `undefined`)
 
 **Meta**
 
--   **since**: 0.5.3
+*   **since**: 0.5.3
 
 ## Luigi.customMessages()
 
@@ -780,9 +786,10 @@ Sends a custom message to all opened micro frontends.
 
 ##### Parameters
 
--   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side.
-    -   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id of the message
-    -   `message.MY_DATA_FIELD` **any** any other message data field
+*   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side.
+
+    *   `message.id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the id of the message
+    *   `message.MY_DATA_FIELD` **any** any other message data field
 
 ##### Examples
 
@@ -796,7 +803,7 @@ Luigi.customMessages().sendToAll({
 
 **Meta**
 
--   **since**: 0.6.2
+*   **since**: 0.6.2
 
 #### send
 
@@ -805,10 +812,11 @@ Use Luigi.elements().getMicrofrontends() to get the iframe id.
 
 ##### Parameters
 
--   `microfrontendId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the micro frontend
--   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side
-    -   `message.id` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the message
-    -   `message.MY_DATA_FIELD` **any** any other message data field
+*   `microfrontendId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the micro frontend
+*   `message` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object containing data to be sent to the micro frontend to process it further. This object is set as an input parameter of the custom message listener on the micro frontend side
+
+    *   `message.id` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the id of the message
+    *   `message.MY_DATA_FIELD` **any** any other message data field
 
 ##### Examples
 
@@ -822,7 +830,7 @@ Luigi.customMessages().send(microfrontend.id, {
 
 **Meta**
 
--   **since**: 0.6.2
+*   **since**: 0.6.2
 
 ## Luigi.ux()
 
@@ -838,7 +846,7 @@ Hides the app loading indicator.
 
 **Meta**
 
--   **since**: 0.6.4
+*   **since**: 0.6.4
 
 #### showAlert
 
@@ -846,14 +854,17 @@ Shows an alert.
 
 ##### Parameters
 
--   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings for the alert
-    -   `settings.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the alert. To add a link to the content, you have to set up the link in the `links` object. The key(s) in the `links` object must be used in the text to reference the links, wrapped in curly brackets with no spaces. If you do not specify any text, the alert is not displayed
-    -   `settings.type` **(`"info"` \| `"success"` \| `"warning"` \| `"error"`)** sets the type of alert
-    -   `settings.links` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** provides links data
-        -   `settings.links.LINK_KEY` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** object containing the data for a particular link. To properly render the link in the alert message refer to the description of the **settings.text** parameter
-            -   `settings.links.LINK_KEY.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text which replaces the link identifier in the alert content
-            -   `settings.links.LINK_KEY.url` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** url to navigate when you click the link. Currently, only internal links are supported in the form of relative or absolute paths
-    -   `settings.closeAfter` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** (optional) time in milliseconds that tells Luigi when to close the Alert automatically. If not provided, the Alert will stay on until closed manually. It has to be greater than `100`
+*   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings for the alert
+
+    *   `settings.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the alert. To add a link to the content, you have to set up the link in the `links` object. The key(s) in the `links` object must be used in the text to reference the links, wrapped in curly brackets with no spaces. If you do not specify any text, the alert is not displayed
+    *   `settings.type` **(`"info"` | `"success"` | `"warning"` | `"error"`)** sets the type of alert
+    *   `settings.links` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** provides links data
+
+        *   `settings.links.LINK_KEY` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** object containing the data for a particular link. To properly render the link in the alert message refer to the description of the **settings.text** parameter
+
+            *   `settings.links.LINK_KEY.text` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** text which replaces the link identifier in the alert content
+            *   `settings.links.LINK_KEY.url` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** url to navigate when you click the link. Currently, only internal links are supported in the form of relative or absolute paths
+    *   `settings.closeAfter` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** (optional) time in milliseconds that tells Luigi when to close the Alert automatically. If not provided, the Alert will stay on until closed manually. It has to be greater than `100`
 
 ##### Examples
 
@@ -880,7 +891,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 0.6.4
+*   **since**: 0.6.4
 
 #### showConfirmationModal
 
@@ -888,12 +899,13 @@ Shows a confirmation modal.
 
 ##### Parameters
 
--   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
-    -   `settings.type` **(`"confirmation"` \| `"success"` \| `"warning"` \| `"error"` \| `"information"`)** the content of the modal type. (Optional)
-    -   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
-    -   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
-    -   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
-    -   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
+*   `settings` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the settings of the confirmation modal. If you do not provide any value for any of the fields, a default value is used
+
+    *   `settings.type` **(`"confirmation"` | `"success"` | `"warning"` | `"error"` | `"information"`)** the content of the modal type. (Optional)
+    *   `settings.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal header (optional, default `"Confirmation"`)
+    *   `settings.body` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the content of the modal body. It supports HTML formatting elements such as `<br>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<mark>`, `<small>`, `<del>`, `<ins>`, `<sub>`, `<sup>`. (optional, default `"Are you sure you want to do this?"`)
+    *   `settings.buttonConfirm` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | `false`)** the label for the modal confirmation button. If set to `false`, the button will not be shown. (optional, default `"Yes"`)
+    *   `settings.buttonDismiss` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the label for the modal dismiss button (optional, default `"No"`)
 
 ##### Examples
 
@@ -916,7 +928,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 0.6.4
+*   **since**: 0.6.4
 
 #### setDocumentTitle
 
@@ -924,7 +936,7 @@ Set the document title
 
 ##### Parameters
 
--   `documentTitle` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+*   `documentTitle` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
 ##### Examples
 
@@ -934,7 +946,7 @@ Luigi.ux().setDocumentTitle('Luigi');
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### getDocumentTitle
 
@@ -950,7 +962,7 @@ Returns **any** a string, which is displayed in the tab.
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### collapseLeftSideNav
 
@@ -958,11 +970,11 @@ Set the collapsed state of the left side navigation
 
 ##### Parameters
 
--   `state` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+*   `state` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**
 
 **Meta**
 
--   **since**: 1.5.0
+*   **since**: 1.5.0
 
 #### openUserSettings
 
@@ -970,7 +982,7 @@ Open user settings dialog
 
 **Meta**
 
--   **since**: 1.7.1
+*   **since**: 1.7.1
 
 #### closeUserSettings
 
@@ -978,7 +990,7 @@ Close user settings dialog
 
 **Meta**
 
--   **since**: 1.7.1
+*   **since**: 1.7.1
 
 ## Luigi.globalSearch()
 
@@ -1000,7 +1012,7 @@ Luigi.globalSearch().openSearchField();
 
 **Meta**
 
--   **since**: 1.3.0
+*   **since**: 1.3.0
 
 #### closeSearchField
 
@@ -1014,7 +1026,7 @@ Luigi.globalSearch().closeSearchField();
 
 **Meta**
 
--   **since**: 1.3.0
+*   **since**: 1.3.0
 
 #### clearSearchField
 
@@ -1028,7 +1040,7 @@ Luigi.globalSearch().clearSearchField();
 
 **Meta**
 
--   **since**: 1.3.0
+*   **since**: 1.3.0
 
 #### showSearchResult
 
@@ -1036,7 +1048,7 @@ Opens the global search result. By standard it is a popover.
 
 ##### Parameters
 
--   `searchResultItems` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** 
+*   `searchResultItems` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)**
 
 ##### Examples
 
@@ -1055,7 +1067,7 @@ Luigi.globalSearch().showSearchResult([searchResultItem1, searchResultItem2]);
 
 **Meta**
 
--   **since**: 1.3.0
+*   **since**: 1.3.0
 
 #### closeSearchResult
 
@@ -1069,7 +1081,7 @@ Luigi.globalSearch().closeSearchResult();
 
 **Meta**
 
--   **since**: 1.3.0
+*   **since**: 1.3.0
 
 #### getSearchString
 
@@ -1083,7 +1095,7 @@ Luigi.globalSearch().getSearchString();
 
 **Meta**
 
--   **since**: 1.3.0
+*   **since**: 1.3.0
 
 #### setSearchString
 
@@ -1091,7 +1103,7 @@ Sets the value of the search input field.
 
 ##### Parameters
 
--   `searchString`  search value
+*   `searchString`  search value
 
 ##### Examples
 
@@ -1101,7 +1113,7 @@ Luigi.globalSearch().setSearchString('searchString');
 
 **Meta**
 
--   **since**: 1.3.0
+*   **since**: 1.3.0
 
 #### setSearchInputPlaceholder
 
@@ -1109,7 +1121,7 @@ Sets the value of the Placeholder search input field.
 
 ##### Parameters
 
--   `searchString`  search value
+*   `searchString`  search value
 
 ##### Examples
 
@@ -1119,7 +1131,7 @@ Luigi.globalSearch().setSearchInputPlaceholder('HERE input Placeholder');
 
 **Meta**
 
--   **since**: 1.7.1
+*   **since**: 1.7.1
 
 ## Luigi.theming()
 
@@ -1148,7 +1160,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### setCurrentTheme
 
@@ -1156,7 +1168,7 @@ Sets the current theme id
 
 ##### Parameters
 
--   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** of a theme object
+*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** of a theme object
 
 ##### Examples
 
@@ -1166,7 +1178,7 @@ Luigi.theming().setCurrentTheme('light')
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### getThemeObject
 
@@ -1174,7 +1186,7 @@ Retrieves a theme object by name.
 
 ##### Parameters
 
--   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a theme id
+*   `id` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a theme id
 
 ##### Examples
 
@@ -1191,7 +1203,7 @@ Returns **[promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### getCurrentTheme
 
@@ -1207,7 +1219,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### isThemingAvailable
 
@@ -1223,7 +1235,7 @@ Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 ## Luigi.featureToggles()
 
@@ -1239,7 +1251,7 @@ Add a feature toggle to an active feature toggles list
 
 ##### Parameters
 
--   `featureToggleName`  
+*   `featureToggleName`  
 
 ##### Examples
 
@@ -1249,7 +1261,7 @@ Luigi.featureToggles().setFeatureToggle('featureToggleName');
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### unsetFeatureToggle
 
@@ -1257,7 +1269,7 @@ Remove a feature toggle from the list
 
 ##### Parameters
 
--   `featureToggleName`  
+*   `featureToggleName`  
 
 ##### Examples
 
@@ -1267,7 +1279,7 @@ Luigi.featureToggles().unsetFeatureToggle('featureToggleName');
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0
 
 #### getActiveFeatureToggleList
 
@@ -1283,4 +1295,4 @@ Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 **Meta**
 
--   **since**: 1.4.0
+*   **since**: 1.4.0

--- a/test/e2e-test-application/e2e/tests/1-angular/luigi-client-link-manager-features.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/luigi-client-link-manager-features.spec.js
@@ -104,6 +104,16 @@ describe('Luigi client linkManager', () => {
         cy.goToOverviewPage();
         cy.goToLinkManagerMethods($iframeBody);
 
+        // navigate with intent - second option
+        cy.wrap($iframeBody)
+          .contains('navigate to settings of project 1 with alternative intent method')
+          .click();
+        cy.expectPathToBe('/projects/pr1/settings');
+        cy.expectSearchToBe('?~project=pr1&~param2=22');
+
+        cy.goToOverviewPage();
+        cy.goToLinkManagerMethods($iframeBody);
+
         //navigate with preserve view functionality
         cy.wrap($iframeBody)
           .contains('with preserved view: project to global settings and back')

--- a/test/e2e-test-application/src/app/project/project.component.html
+++ b/test/e2e-test-application/src/app/project/project.component.html
@@ -587,14 +587,14 @@
               class="fd-link"
               (click)="
                 linkManager().navigate(
-                  '/#?intent=Sales-settings?project=pr2&param2=bcd'
+                  '/#?intent=Sales-settings?param1=abc&param2=bcd'
                 )
               "
             >
               navigate to settings with intent with parameters</a
             >
             <app-code-snippet
-              data="linkManager().navigate('/#?intent=Sales-settings?project=pr2&param2=bcd')"
+              data="linkManager().navigate('/#?intent=Sales-settings?param1=abc&param2=bcd')"
             >
             </app-code-snippet>
           </li>
@@ -604,7 +604,7 @@
               class="fd-link"
               (click)="
                 linkManager().navigateToIntent(
-                  'Sales-settings', {project: 'pr1', param2: '22'}
+                  'Component-settings', {project: 'pr1', param2: '22'}
                 )
               "
             >
@@ -612,7 +612,7 @@
               navigateToIntent
             </a>
             <app-code-snippet
-              data="linkManager().navigateToIntent('Sales-settings', {project: 'pr1', param2: '22'})"
+              data="linkManager().navigateToIntent('Component-settings', {project: 'pr1', param2: '22'})"
             >
             </app-code-snippet>
           </li>
@@ -754,20 +754,6 @@
               >Go to /projects/pr2/virtual-tree NOT using withoutSync()
             </a>
             <app-code-snippet data="linkManager().navigate('/projects/pr2/virtual-tree')">
-            </app-code-snippet>
-          </li>
-
-          <li class="fd-list__item">
-            <a
-              href="javascript:void(0)"
-              class="fd-link navigate-withSync-virtual-tree"
-              (click)="navigateWithSync('/projects/pr2/virtual-tree')"
-              data-testid="navigate-withSync-virtual-tree"
-              >Go to settings with new go to intent
-            </a>
-            <app-code-snippet
-              data="linkManager().navigateToIntent('/projects/pr2/virtual-tree')"
-            >
             </app-code-snippet>
           </li>
         </ul>

--- a/test/e2e-test-application/src/app/project/project.component.html
+++ b/test/e2e-test-application/src/app/project/project.component.html
@@ -587,14 +587,32 @@
               class="fd-link"
               (click)="
                 linkManager().navigate(
-                  '/#?intent=Sales-settings?param1=abc&param2=bcd'
+                  '/#?intent=Sales-settings?project=pr2&param2=bcd'
                 )
               "
             >
               navigate to settings with intent with parameters</a
             >
             <app-code-snippet
-              data="linkManager().navigate('/#?intent=Sales-settings?param1=abc&param2=bcd')"
+              data="linkManager().navigate('/#?intent=Sales-settings?project=pr2&param2=bcd')"
+            >
+            </app-code-snippet>
+          </li>
+          <li class="fd-list__item">
+            <a
+              href="javascript:void(0)"
+              class="fd-link"
+              (click)="
+                linkManager().navigateToIntent(
+                  'Sales-settings', {project: 'pr1', param2: '22'}
+                )
+              "
+            >
+              navigate to settings of project 1 with alternative intent method:
+              navigateToIntent
+            </a>
+            <app-code-snippet
+              data="linkManager().navigateToIntent('Sales-settings', {project: 'pr1', param2: '22'})"
             >
             </app-code-snippet>
           </li>
@@ -736,6 +754,20 @@
               >Go to /projects/pr2/virtual-tree NOT using withoutSync()
             </a>
             <app-code-snippet data="linkManager().navigate('/projects/pr2/virtual-tree')">
+            </app-code-snippet>
+          </li>
+
+          <li class="fd-list__item">
+            <a
+              href="javascript:void(0)"
+              class="fd-link navigate-withSync-virtual-tree"
+              (click)="navigateWithSync('/projects/pr2/virtual-tree')"
+              data-testid="navigate-withSync-virtual-tree"
+              >Go to settings with new go to intent
+            </a>
+            <app-code-snippet
+              data="linkManager().navigateToIntent('/projects/pr2/virtual-tree')"
+            >
             </app-code-snippet>
           </li>
         </ul>

--- a/test/e2e-test-application/src/luigi-config/extended/navigation.js
+++ b/test/e2e-test-application/src/luigi-config/extended/navigation.js
@@ -30,7 +30,7 @@ class Navigation {
     {
       semanticObject: 'Sales',
       action: 'settings',
-      pathSegment: '/projects/pr2/settings'
+      pathSegment: '/projects/:project/settings'
     }
   ];
   nodeAccessibilityResolver = navigationPermissionChecker;

--- a/test/e2e-test-application/src/luigi-config/extended/navigation.js
+++ b/test/e2e-test-application/src/luigi-config/extended/navigation.js
@@ -30,6 +30,11 @@ class Navigation {
     {
       semanticObject: 'Sales',
       action: 'settings',
+      pathSegment: '/projects/pr2/settings'
+    },
+    {
+      semanticObject: 'Component',
+      action: 'settings',
       pathSegment: '/projects/:project/settings'
     }
   ];


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Introduces : `linkManager().navigateToIntent`
Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
 parameters. 

The new linkManager **`navigateToIntent`**  method internally generates a url of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given input arguments. This then follows a call to the original linkManager.navigate(...) function.
   * Consequentially the following calls shall have the exact same effect:
   * - `LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})`
   * - `LuigiClient.linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')`
   
#### Changes proposed in this pull request:

- navigateToIntent() added
-  add support for dynamic path segments in intentMappings
i.e.: `/projects/:project/settings` is converted to `/projects/pr2/settings` if the {project:pr2} parameter is given through the intent.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #2184 