### PR TITLE
LuigiClient linkManager wrong navigation scope in modal

### DIFF
--- a/core/src/App.html
+++ b/core/src/App.html
@@ -165,7 +165,7 @@
   export let getTranslation;
 
   let showLoadingIndicator = false;
-
+  let currentIframe;
   let mfSplitView = {
     displayed: false
   };
@@ -512,7 +512,11 @@
       path = intentPath ? intentPath : path;
     } else if (params.relative) {
       // relative
-      path = Routing.concatenatePath(getSubPath(currentNode), params.link);
+      console.log('currentIframe', currentIframe);
+      path = Routing.concatenatePath(
+        getSubPath(currentIframe.luigi.currentNode),
+        params.link
+      );
     }
     if (params.nodeParams && Object.keys(params.nodeParams).length) {
       path += path.includes('?') ? '&' : '?';
@@ -1051,7 +1055,9 @@
     const defaultPageErrorHandler = LuigiConfig.getConfigValue(
       'navigation.defaults.pageErrorHandler'
     );
-    const defaultRunTimeErrorHandler = LuigiConfig.getConfigValue('navigation.defaults.runTimeErrorHandler')
+    const defaultRunTimeErrorHandler = LuigiConfig.getConfigValue(
+      'navigation.defaults.runTimeErrorHandler'
+    );
     const config = {
       iframe: null,
       navigateOk: null,
@@ -1095,6 +1101,7 @@
       const iframe = IframeHelpers.getValidMessageSource(e);
       if (!iframe) return;
       iframe._ready = true;
+      currentIframe = iframe;
 
       if ('custom' === e.data.msg) {
         const customMessagesListeners =
@@ -1404,14 +1411,21 @@
           e.data.data.id,
           e.data.data.operation,
           e.data.data.params
-        )
+        );
       }
 
-      if('luigi-runtime-error-handling'===e.data.msg){
+      if ('luigi-runtime-error-handling' === e.data.msg) {
         let currentNode = iframe.luigi.currentNode;
-        if(currentNode && currentNode.runTimeErrorHandler && GenericHelpers.isFunction(currentNode.runTimeErrorHandler.errorFn)){
+        if (
+          currentNode &&
+          currentNode.runTimeErrorHandler &&
+          GenericHelpers.isFunction(currentNode.runTimeErrorHandler.errorFn)
+        ) {
           currentNode.runTimeErrorHandler.errorFn(e.data.errorObj, currentNode);
-        }else if(defaultRunTimeErrorHandler && GenericHelpers.isFunction(defaultRunTimeErrorHandler.errorFn)){
+        } else if (
+          defaultRunTimeErrorHandler &&
+          GenericHelpers.isFunction(defaultRunTimeErrorHandler.errorFn)
+        ) {
           defaultRunTimeErrorHandler.errorFn(e.data.errorObj, currentNode);
         }
       }

--- a/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/1-angular/navigation.spec.js
@@ -325,6 +325,25 @@ describe('Navigation', () => {
       cy.get('[data-testid=luigi-alert]').should('have.class', 'fd-message-strip--error');
       cy.expectPathToBe('/overview');
     });
+
+    it('navigate to a relative path from modal', () => {
+      cy.visit('/projects/pr1');
+      cy.getIframeBody().then($iframeBody => {
+        cy.wrap($iframeBody)
+          .find('[data-testid=open-pr2-modal]')
+          .click();
+      });
+
+      cy.get('[data-testid=modal-mf] iframe')
+        .iframe()
+        .then(modal => {
+          cy.wrap(modal)
+            .contains('relative: to stakeholders')
+            .click();
+
+          cy.expectPathToBe('/projects/pr2/users/groups/stakeholders');
+        });
+    });
   });
 
   describe('Node activation hook', () => {

--- a/test/e2e-test-application/src/app/project/project.component.html
+++ b/test/e2e-test-application/src/app/project/project.component.html
@@ -78,7 +78,24 @@
         </p>
       </div>
     </div>
-
+    <div class="fd-layout-panel luigi__margin-bottom--small">
+      <div class="fd-layout-panel__header">
+        <div class="fd-layout-panel__head">
+          <h3 class="fd-layout-panel__title">
+            Open project two in a modal
+          </h3>
+        </div>
+      </div>
+      <div class="fd-layout-panel__body">
+        <button
+          class="fd-button"
+          data-testid="open-pr2-modal"
+          (click)="linkManager().openAsModal('/projects/pr2/')"
+        >
+          Open project two in a modal
+        </button>
+      </div>
+    </div>
     <div class="fd-layout-panel luigi__margin-bottom--small">
       <div class="fd-layout-panel__header">
         <div class="fd-layout-panel__head">


### PR DESCRIPTION
**Description**
When navigate to a relative path from an opened micro-frontend in a modal. 
The navigated path should go from the URL of the modal.

Changes proposed in this pull request:
- Check the scope of current active iframe. Relative navigation should go from there.

**Related issue(s)**
Fixes #2211 
