### PR TITLE
Make navigateToIntent parameters optional

### DIFF
--- a/client/luigi-client.d.ts
+++ b/client/luigi-client.d.ts
@@ -315,11 +315,11 @@ export declare interface LinkManager {
    * - linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    * - linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
    * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: `<semanticObject>-<action>`
-   * @param {Object} params an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`
+   * @param {Object} params an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`. (optional, default `{}`)
    * @example
    * LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    */
-  navigateToIntent: (semanticSlug: string, params: Object) => void;
+  navigateToIntent: (semanticSlug: string, params?: Object) => void;
 
   /** @lends linkManager */
   /**

--- a/client/src/linkManager.js
+++ b/client/src/linkManager.js
@@ -98,11 +98,11 @@ export class linkManager extends LuigiClientBase {
    * - linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    * - linkManager().navigate('/#?intent=Sales-settings?project=pr2&user=john')
    * @param {string} semanticSlug concatenation of semantic object and action connected with a dash (-), i.e.: `<semanticObject>-<action>`
-   * @param {Object} params an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`
+   * @param {Object} params an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`. (optional, default `{}`)
    * @example
    * LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
    */
-  navigateToIntent(semanticSlug, params) {
+  navigateToIntent(semanticSlug, params = {}) {
     let newPath = '#?intent=';
     newPath += semanticSlug;
     if (params) {

--- a/docs/luigi-client-api.md
+++ b/docs/luigi-client-api.md
@@ -373,8 +373,7 @@ The Link Manager allows you to navigate to another route. Use it instead of an i
 
 #### navigateToIntent
 
-Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing
-parameters.
+Offers an alternative way of navigating with intents. This involves specifying a semanticSlug and an object containing parameters, if any.
 This method internally generates a URL of the form `#?intent=<semantic object>-<action>?<param_name>=<param_value>` through the given input arguments. This then follows a call to the original `linkManager.navigate(...)` function.
 Conequently the following calls shall have the exact same effect:
 
@@ -384,12 +383,13 @@ Conequently the following calls shall have the exact same effect:
 ##### Parameters
 
 -   `semanticSlug` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** concatenation of semantic object and action connected with a dash (-), i.e.: `<semanticObject>-<action>`
--   `params` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`
+-   `params` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** an object representing all the parameters passed, i.e.: `{param1: '1', param2: 2, param3: 'value3'}`. (optional, default `{}`)
 
 ##### Examples
 
 ```javascript
 LuigiClient.linkManager().navigateToIntent('Sales-settings', {project: 'pr2', user: 'john'})
+LuigiClient.linkManager().navigateToIntent('Sales-settings')
 ```
 
 #### withoutSync

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
    },
    "husky": {
       "hooks": {
-         "pre-commit": "npm run code-quality && ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh && ./scripts/hooks/prevent-illegal-characters.sh"
+         "pre-commit": "npm run code-quality && ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/prevent-illegal-characters.sh"
       }
    },
    "codeQuality": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
    },
    "husky": {
       "hooks": {
-         "pre-commit": "npm run code-quality && ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/prevent-illegal-characters.sh"
+         "pre-commit": "npm run code-quality && ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh && ./scripts/hooks/prevent-illegal-characters.sh"
       }
    },
    "codeQuality": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Noticed during trying it out on different scenario that parameters must be optional type, as one can navigate to an intent mapping with/without any parameters.

**Changes proposed in this pull request:**
`navigateToIntent(semanticSlag: string, params: Object)`

changed to:
`navigateToIntent(semanticSlag: string, params?: Object)`

as parameters should be optional.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
