### PR TITLE
Resolve intent path to actual path

### DIFF
--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -137,6 +137,7 @@ class RoutingClass {
       const intentPath = RoutingHelpers.getIntentPath(hash);
       if (intentPath) {
         // if intent faulty or illegal then skip
+        history.replaceState(window.state, '', intentPath);
         return intentPath;
       }
     }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- replaceState with the actual path when loading manually edited route

So: 
 http://localhost:4200/#?intent=Sales-settings?param1=abc&param2=bcd
is translate to its actual path
http://localhost:4200/projects/pr2/settings?~param1=abc&~param2=bcd

Also, with hashRouting enabled:  http://localhost:4200/#?intent=Sales-settings?param1=abc&param2=bcd
should translate to :
 http://localhost:4200/#/projects/pr2/settings?~param1=abc&~param2=bcd


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #2225 