### PR TITLE
Disbale doublle scroll when zooming in the browser

### DIFF
--- a/core/src/App.html
+++ b/core/src/App.html
@@ -1778,7 +1778,7 @@
   .iframeContainer {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-    line-height: initial;
+    line-height: initial; /*disable the double-scroll when zooming out the browser*/
   }
 
   .iframeContainer :global(iframe) {

--- a/core/src/App.html
+++ b/core/src/App.html
@@ -1778,6 +1778,7 @@
   .iframeContainer {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
+    line-height: initial;
   }
 
   .iframeContainer :global(iframe) {


### PR DESCRIPTION
Fixes #2418 

Fix the bug with double-scroll when Zooming Out the browser
![Screenshot 2021-12-22 at 18 28 58](https://user-images.githubusercontent.com/2720077/147132219-b010f89b-2dcc-4a2a-afc8-d773a23254c1.png)
