### PR TITLE
Fix typo in code example

### DIFF
--- a/client/src/uxManager.js
+++ b/client/src/uxManager.js
@@ -146,7 +146,7 @@ class UxManager extends LuigiClientBase {
    *  links: {
    *    goToHome: { text: 'homepage', url: '/overview' },
    *    goToOtherProject: { text: 'other project', url: '/projects/pr2' },
-   *    relativePath: { text: 'relative hide side nav', url: 'hideSideNav' }
+   *    relativePath: { text: 'relative hide side nav', url: 'hideSideNav' },
    *    neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' }
    *  },
    *  closeAfter: 3000

--- a/core/src/core-api/ux.js
+++ b/core/src/core-api/ux.js
@@ -46,7 +46,7 @@ class LuigiUX {
    *  links: {
    *    goToHome: { text: 'homepage', url: '/overview' },
    *    goToOtherProject: { text: 'other project', url: '/projects/pr2' },
-   *    relativePath: { text: 'relative hide side nav', url: 'hideSideNav' }
+   *    relativePath: { text: 'relative hide side nav', url: 'hideSideNav' },
    *    neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' }
    *  },
    *  closeAfter: 3000

--- a/docs/luigi-client-api.md
+++ b/docs/luigi-client-api.md
@@ -926,7 +926,7 @@ Removes the backdrop.
 
 #### setDirtyStatus
 
-This method informs the main application that there are unsaved changes in the current view of the iframe. It can be used to prevent navigation away from the current view, for example with form fields which were edited but not submitted. However, this functionality is not restricted to forms. 
+This method informs the main application that there are unsaved changes in the current view of the iframe. It can be used to prevent navigation away from the current view, for example with form fields which were edited but not submitted. However, this functionality is not restricted to forms.
 
 If you use `withoutSync()` together with `setDirtyStatus()`, this is a special case in which the dirty state logic needs to be handled by the micro frontend. For example, if the user navigates with an Angular router, which would trigger `withoutSync()`, Angular needs to take care about dirty state, prevent the navigation and ask for permission to navigate away, through `uxManager().showConfirmationModal(settings)`.
 ##### Parameters
@@ -993,7 +993,7 @@ const settings = {
  links: {
    goToHome: { text: 'homepage', url: '/overview' },
    goToOtherProject: { text: 'other project', url: '/projects/pr2' },
-   relativePath: { text: 'relative hide side nav', url: 'hideSideNav' }
+   relativePath: { text: 'relative hide side nav', url: 'hideSideNav' },
    neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' }
  },
  closeAfter: 3000

--- a/docs/luigi-core-api.md
+++ b/docs/luigi-core-api.md
@@ -895,7 +895,7 @@ const settings = {
  links: {
    goToHome: { text: 'homepage', url: '/overview' },
    goToOtherProject: { text: 'other project', url: '/projects/pr2' },
-   relativePath: { text: 'relative hide side nav', url: 'hideSideNav' }
+   relativePath: { text: 'relative hide side nav', url: 'hideSideNav' },
    neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' }
  },
  closeAfter: 3000


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

There is a typo in the [UX().showAlert sample code](https://docs.luigi-project.io/docs/luigi-core-api?section=ux). There should be a `,` in the end of `
relativePath: { text: 'relative hide side nav', url: 'hideSideNav' },

**Related issue(s)**
Resolves #2585
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
