### PR TITLE
Fix empty nodeParams on browser back navigation

### DIFF
--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -128,7 +128,8 @@ class RoutingClass {
       const intentPath = RoutingHelpers.getIntentPath(hash);
       return intentPath ? intentPath : '/';
     }
-    const path = (window.history.state && window.history.state.path) || window.location.pathname;
+    const params = window.location.search ? window.location.search : '';
+    const path = (window.history.state && window.history.state.path) || window.location.pathname + params;
     return path
       .split('/')
       .slice(1)
@@ -272,6 +273,7 @@ class RoutingClass {
       const hideNav = LuigiConfig.getConfigBooleanValue('settings.hideNavigation');
       const params = RoutingHelpers.parseParams(pathUrlRaw.split('?')[1]);
       const nodeParams = RoutingHelpers.getNodeParams(params);
+
       const viewGroup = RoutingHelpers.findViewGroup(nodeObject);
       const urlParamsRaw = decodeURIComponent(pathUrlRaw.split('?')[1] || '');
       const currentNode =

--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -273,7 +273,6 @@ class RoutingClass {
       const hideNav = LuigiConfig.getConfigBooleanValue('settings.hideNavigation');
       const params = RoutingHelpers.parseParams(pathUrlRaw.split('?')[1]);
       const nodeParams = RoutingHelpers.getNodeParams(params);
-
       const viewGroup = RoutingHelpers.findViewGroup(nodeObject);
       const urlParamsRaw = decodeURIComponent(pathUrlRaw.split('?')[1] || '');
       const currentNode =

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -837,6 +837,16 @@ describe('Routing', function() {
       assert.equal(Routing.getModifiedPathname(), mockPathName);
     });
 
+    it('without state and with query params', () => {
+      const mockPathName = 'projects?~test=param';
+      sinon.stub(window.history, 'state').returns(null);
+      sinon.stub(window, 'location').value({
+        pathname: '/projects',
+        search: '?~test=param'
+      });
+      assert.equal(Routing.getModifiedPathname(), mockPathName);
+    });
+
     it('with state path', () => {
       sinon.stub(window.history, 'state').value({
         path: '/this/is/some/'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Add parameters to pathname when hash routing disabled.

**Related issue(s)**
Fixes #2689 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
