### PR TITLE
Disable keyboard accessibility for user settings dialog

### DIFF
--- a/core/src/UserSettingsDialog.svelte
+++ b/core/src/UserSettingsDialog.svelte
@@ -41,6 +41,11 @@
   let isComboOpen;
   let closeDropDown;
 
+  onDestroy(() => {
+    // Enable keyboard accessibility to the rest of the elements after dialog is closed
+    IframeHelpers.enableA11YKeyboardBackdropExceptClassName('.lui-usersettings-dialog');
+  });
+
   onMount(() => {
     const usLocalizationConfig = LuigiConfig.getConfigValue(
       'userSettings.userSettingsDialog'
@@ -109,6 +114,9 @@
           dispatch('close');
         }
       });
+
+    // disable keyboard accessibility for all elements outside the user settings dialog
+    IframeHelpers.disableA11YKeyboardExceptClassName('.lui-usersettings-dialog');
   });
 
   function prepareUserSettingsObj(userSettingGroups, storedUserSettingsData) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Disables keyboard accessibility to the rest of the elements when user settings dialog is opened

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
