### PR TITLE
fix patchy product switch grid icon

### DIFF
--- a/core/src/navigation/ProductSwitcher.svelte
+++ b/core/src/navigation/ProductSwitcher.svelte
@@ -108,7 +108,6 @@
               title={config.label}
               data-testid={getTestId(config)}
             >
-              <div class="lui-product-switch__icon">
                 {#if hasOpenUIicon(config)}
                   <!-- default: sap-icon--grid -->
                   <i class="sap-icon {getSapIconStr(config.icon)}" />
@@ -118,7 +117,6 @@
                     alt={config.altText ? config.altText : ''}
                   />
                 {/if}
-              </div>
             </button>
           </div>
           <div


### PR DESCRIPTION
used to look like that on windows/chrome

![image.png](https://images.zenhubusercontent.com/5b8418bc79c9991fcdb9a678/e7057a0f-8a8a-49e8-ac47-bffdb6b6ace6)