### PR TITLE
render tag

### DIFF
--- a/core/src/App.svelte
+++ b/core/src/App.svelte
@@ -715,6 +715,7 @@
   let hideSideNav;
   let noAnimation;
   let previousWindowWidth;
+  let configTag;
 
   const closeLeftNav = () => {
     document.body.classList.remove('lui-leftNavToggle');
@@ -908,7 +909,7 @@
       // reset all modal list
       mfModalList = [];
       return;
-    } 
+    }
     // remove the item with specified index from the list
     mfModalList = mfModalList.filter((item, i) => index !== i);
   };
@@ -916,7 +917,7 @@
   resetMicrofrontendModalData();
 
   /**
-   * Opens the (iframe/wc) view in a modal given in the nodepath 
+   * Opens the (iframe/wc) view in a modal given in the nodepath
    * @param nodepath {string} the path of the view to open
    * @param settings {Object} the respective modal settings
    */
@@ -948,7 +949,7 @@
   /**
    * Event handler called when the iframe of the modal is created inside Modal component
    * @param event {Object} event data of the instantiated Modal component instance
-   * @param index {number} the index of the modal to be instantiated 
+   * @param index {number} the index of the modal to be instantiated
    */
   const modalIframeCreated = (event, index) => {
     mfModalList[index].modalIframe = event.detail.modalIframe;
@@ -958,7 +959,7 @@
   /**
    * Event handler called when the web component of the modal is created inside Modal component
    * @param event {Object} event data of the instantiated Modal component instance
-   * @param index {number} the index of the modal to be instantiated 
+   * @param index {number} the index of the modal to be instantiated
    */
   const modalWCCreated = (event, index) => {
     mfModalList[index].modalWC = event.detail.modalWC;
@@ -1124,7 +1125,7 @@
   /**
    * Builds the current path based on the navigation params received
    * @param params {Object} navigation options
-   * @returns {string} the path built 
+   * @returns {string} the path built
    */
   const buildPathForGetCurrentRoute = (params) => {
     let localNavPath = navigationPath;
@@ -1140,7 +1141,7 @@
 
     let path = params.link;
     let currentNodeViewUrl = getSubPath(currentNode, pathParams);
-  
+
     if (params.fromVirtualTreeRoot) {
       // from a parent node specified with virtualTree: true
       const virtualTreeNode = [...localNavPath].reverse().find((n) => n.virtualTree);
@@ -1232,7 +1233,7 @@
       const topMostModal = mfModalList[(mfModalList.length - 1)];
       const modalIframe = topMostModal && topMostModal.modalIframe;
       const modalIframeData = topMostModal && topMostModal.modalIframeData;
-      
+
       const specialIframeProps = {
         modalIframe,
         modalIframeData,
@@ -1435,10 +1436,10 @@
                 });
               // close all modals to allow navigation to the non-special view
               mfModalList.forEach((m, index) => {
-                // close modals 
+                // close modals
                 closeModal(index);
               });
-              
+
               closeSplitView();
               closeDrawer();
               isNavigationSyncEnabled = true;
@@ -1828,6 +1829,7 @@
     breadcrumbsEnabled =
       GenericHelpers.requestExperimentalFeature('breadcrumbs');
     searchProvider = LuigiConfig.getConfigValue('globalSearch.searchProvider');
+    configTag = LuigiConfig.getConfigValue('tag');
   });
 </script>
 
@@ -1837,6 +1839,7 @@
   class="{hideNav ? 'no-nav' : ''} {hideSideNav
     ? 'no-side-nav'
     : ''} {noAnimation ? 'no-animation' : ''}"
+  configversion="{configTag}"
 >
   {#if alerts && alerts.length}
     <Alerts alertQueue={alerts} on:alertDismiss={handleAlertDismissExternal} />


### PR DESCRIPTION
allows to specify a tag at the root level of luigi config, which is rendered as attribute value in #app div.

With this, you can wait in tests until a certain version of config is applied in e2e test, e.g. by calling
```
cy.contains('#app[configversion="myVersion"]')
```