### PR TITLE
Tooltip for categories expand collapse button

### DIFF
--- a/core/src/navigation/LeftNav.svelte
+++ b/core/src/navigation/LeftNav.svelte
@@ -462,6 +462,10 @@
         : expandNavTooltip;
     }
   }
+
+  function setTitleForCategoryButton(nodes, expandedCategories){
+    return isExpanded(nodes, expandedCategories)?nodes.metaInfo.titleCollapseButton:nodes.metaInfo.titleExpandButton;
+  }
 </script>
 
 <svelte:window
@@ -592,11 +596,11 @@
                             <StatusBadge {node} />
                           </span>
                           {#if node.externalLink && node.externalLink.url}
-                          <i
-                            class="fd-nested-list__icon sap-icon sap-icon--action"
-                            role="presentation"
-                          />
-                          {/if}                     
+                            <i
+                              class="fd-nested-list__icon sap-icon sap-icon--action"
+                              role="presentation"
+                            />
+                          {/if}
                           {#if node.badgeCounter}
                             <BadgeCounter {node} />
                           {/if}
@@ -672,6 +676,10 @@
                         aria-label="Expand categories"
                         aria-haspopup="true"
                         aria-expanded={isExpanded(nodes, expandedCategories)}
+                        title={setTitleForCategoryButton(
+                          nodes,
+                          expandedCategories
+                        )}
                         on:click|preventDefault={() =>
                           setExpandedState(
                             nodes,
@@ -723,10 +731,10 @@
                                 )}
                               >
                                 <span class="fd-nested-list__title">
-                                  {$getTranslation(node.label)}                                  
+                                  {$getTranslation(node.label)}
                                   <StatusBadge {node} />
-                                </span>                                
-                                
+                                </span>
+
                                 {#if node.externalLink && node.externalLink.url}
                                   <i class="sap-icon--action" />
                                 {/if}
@@ -779,7 +787,7 @@
                                       )}
                                     >
                                       <span class="fd-nested-list__title">
-                                        {$getTranslation(node.label)}                                        
+                                        {$getTranslation(node.label)}
                                         <StatusBadge {node} />
                                       </span>
                                       {#if node.externalLink && node.externalLink.url}

--- a/docs/navigation-parameters-reference.md
+++ b/docs/navigation-parameters-reference.md
@@ -219,6 +219,8 @@ Node parameters are all the parameters that can be added to an individual naviga
   - **collapsible** if set to `true`, category items are hidden at first. To expand them, click the main category node.
   - **testId** is a string where you can define your own custom `testId` for  E2E tests. If nothing is specified, it is the node's label written as one word in lower case, for example`label`.
   - **id** if this property is defined all nodes with the same category `id` will be grouped.
+  - **titleExpandButton** adds the HTML `title` attribute with the defined value to the expand button.
+  - **titleCollapseButton** adds the HTML `title` attribute with the defined value to the collapse button.
 
 ### children
 - **type**: array | function

--- a/test/e2e-test-application/e2e/tests/0-js-test-app/js-test-app-navigation.spec.js
+++ b/test/e2e-test-application/e2e/tests/0-js-test-app/js-test-app-navigation.spec.js
@@ -117,6 +117,51 @@ describe('JS-TEST-APP', () => {
         cy.contains('.fd-shellbar').should('not.exist');
       });
     });
+    describe('Tooltext for category button', () => {
+      let newConfig;
+      beforeEach(() => {
+        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig.navigation.nodes[0].children[0].category = {
+          label: 'Test Category',
+          collapsible: true,
+          titleExpandButton: 'Expand test category',
+          titleCollapseButton: 'Collapse test category'
+        };
+        newConfig.tag = 'tooltip-test';
+      });
+      it('Tooltip for expand/collapse button', () => {
+        cy.visitTestApp('/', newConfig);
+        cy.get('#app[configversion="tooltip-test"]');
+        cy.get('.lui-collapsible-item').contains('Test Category');
+        cy.get('.lui-collapsible-item button').should('have.attr', 'title', 'Expand test category');
+        cy.get('.lui-collapsible-item')
+          .contains('Test Category')
+          .click();
+        cy.get('.lui-collapsible-item button').should('have.attr', 'title', 'Collapse test category');
+      });
+      it('Tooltip for expand button not defined', () => {
+        delete newConfig.navigation.nodes[0].children[0].category.titleExpandButton;
+        cy.visitTestApp('/', newConfig);
+        cy.get('#app[configversion="tooltip-test"]');
+        cy.get('.lui-collapsible-item').contains('Test Category');
+        cy.get('.lui-collapsible-item button').should('not.have.attr', 'title');
+        cy.get('.lui-collapsible-item')
+          .contains('Test Category')
+          .click();
+        cy.get('.lui-collapsible-item button').should('have.attr', 'title', 'Collapse test category');
+      });
+      it('Tooltip for collapse button not defined', () => {
+        delete newConfig.navigation.nodes[0].children[0].category.titleCollapseButton;
+        cy.visitTestApp('/', newConfig);
+        cy.get('#app[configversion="tooltip-test"]');
+        cy.get('.lui-collapsible-item').contains('Test Category');
+        cy.get('.lui-collapsible-item button').should('have.attr', 'title', 'Expand test category');
+        cy.get('.lui-collapsible-item')
+          .contains('Test Category')
+          .click();
+        cy.get('.lui-collapsible-item button').should('not.have.attr', 'title');
+      });
+    });
   });
   describe('ContextSwitcher', () => {
     let newConfig;


### PR DESCRIPTION
Fixes #3007 

Added two properties to the category object

```
category:{
...
titleExpandButton: 'Expand this category',
titleCollapseButton: 'Collapse this category'
}
```