### PR TITLE
Rename source map to fit with webpack 5 requirement

### DIFF
--- a/core/webpack.config.js
+++ b/core/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = {
     path: __dirname + '/public',
     filename: '[name].js',
     chunkFilename: '[name].[id].js',
-    sourceMapFilename: '[name].svelte.map.js'
+    sourceMapFilename: '[name].svelte.map'
   },
   module: {
     rules: [commonRules.svelte, commonRules.css, commonRules.urls]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**

Changes proposed in this pull request:
- Fixes issue with **Webpack 5** bundling our source map thinking its javascript since it ends with **.js**. Issue comes from #2938 

- **Follow up:** After release,  update core example **react**, **js**, **fiddle** to latest luigi version and remove the following **TerserPlugin** line :
```
      new TerserPlugin({
        exclude: /\.svelte\.map\.js$/
      })
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #2965 