### PR TITLE
Fix pageErrorHandler.timeout documentation

### DIFF
--- a/docs/navigation-parameters-reference.md
+++ b/docs/navigation-parameters-reference.md
@@ -125,7 +125,7 @@ config.navigation.defaults = {
 - **description**: gives you the possibility to handle a situation in which Luigi Client doesn't respond. By default, it will redirect to the home page if nothing else is specified. **timeout** is required.
 - **default**: the parameter **defaults.pageErrorHandler** is not specified by default, and you can overwrite it using the **pageErrorHandler** value on a single node level.
 - **attributes**:
-  - **timeout** amount of time after which redirection will take effect.
+  - **timeout** amount of time in milliseconds after which redirection will take effect.
   - **viewUrl** specifies the location to redirect to on the micro frontend level (the main URL is not changed).
   - **redirectPath** specifies the location to redirect to on the Luigi level (the main URL is changed).
   - **errorFn** used to handle different scenarios other than redirection.
@@ -592,7 +592,7 @@ runTimeErrorHandler: {
 - **type**: object
 - **description**: gives you the possibility to handle a situation in which Luigi Client doesn't respond. By default, it will redirect to the home page if nothing else is specified. **timeout** is required.
 - **attributes**:
-  - **timeout** amount of time after which redirection will take effect.
+  - **timeout** amount of time in milliseconds after which redirection will take effect. (For example, `timeout: 500`).
   - **viewUrl** specifies the location to redirect to on the micro frontend level (the main URL is not changed).
   - **redirectPath** specifies the location to redirect to on the Luigi level (the main URL is changed).
   - **errorFn** used to handle different scenarios other than redirection.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**

Changes proposed in this pull request:

- The pageErrorHandler.timeout documentation lacked a unit
- Tested it with this code and `timeout:5000` which led to redirect after 5 seconds. Therefore the unit is milliseconds:
<img width="542" alt="Screenshot 2023-01-20 at 09 19 20" src="https://user-images.githubusercontent.com/49867570/214038512-13dd3250-daf9-4b8f-af5f-145ae142effb.png">
- Added unit to docu



**Related issue(s)**
Resolves #3127 
