### PR TITLE
Fix failing prettify setup

### DIFF
--- a/code_quality.js
+++ b/code_quality.js
@@ -73,7 +73,7 @@ const fileToExclude = (file, stat) => {
  * @returns {Promise<*>}: promise wiht list of files.
  */
 const getChangedFiles = async () => {
-  const committedGitFiles = await gitChangedFiles();
+  const committedGitFiles = await gitChangedFiles({ baseBranch: 'main' });
   return committedGitFiles.unCommittedFiles.filter(file => fs.existsSync(file) && !file.endsWith('package-lock.json'));
 };
 

--- a/core/src/navigation/ContextSwitcherNav.svelte
+++ b/core/src/navigation/ContextSwitcherNav.svelte
@@ -73,7 +73,7 @@
             {:else}
               <a
                 href={getRouteLink(node)}
-                on:click={(event) => {
+                on:click={event => {
                   NavigationHelpers.handleNavAnchorClickedWithoutMetaKey(event);
                 }}
                 class="fd-menu__link {label === selectedLabel
@@ -100,7 +100,7 @@
           >
             <a
               href={getRouteLink(node)}
-              on:click={(event) => {
+              on:click={event => {
                 NavigationHelpers.handleNavAnchorClickedWithoutMetaKey(event);
               }}
               class="fd-menu__link"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
       "code-quality-prettier": "node code_quality.js -- mode=pre_commit_prettier",
       "code-quality-eslint": "node code_quality.js -- mode=pre_commit__eslint",
       "full-code-quality": "node code_quality.js -- mode=full",
-      "full-code-quality-prettier": "node code_quality.js -- mode=full_prettier sourcePaths=core/src,client/src,test/e2e-test-application/e2e,test/e2e-test-application/src",
+      "full-code-quality-prettier": "node code_quality.js -- mode=full_prettier sourcePaths=core/src,client/src,test/e2e-test-application/cypress/e2e,test/e2e-test-application/src",
       "full-code-quality-eslint": "node code_quality.js -- mode=full_eslint",
       "full-code-quality-eslint-core": "node code_quality.js -- mode=full_eslint sourcePaths=core/src,core/test report=core_full_eslint_report.html",
       "full-code-quality-eslint-client": "node code_quality.js -- mode=full_eslint sourcePaths=client/src report=client_full_eslint_report.html",

--- a/scripts/hooks/remove-test-prefixes.sh
+++ b/scripts/hooks/remove-test-prefixes.sh
@@ -36,7 +36,7 @@ while read LINE; do
     cleanFiles "${LINE}"
 done <<HERE
 $BASE_DIR/../../core/test
-$BASE_DIR/../../test/e2e-test-application/e2e
+$BASE_DIR/../../test/e2e-test-application/cypress/e2e
 $BASE_DIR/../../test/e2e-test-application/src/app
 HERE
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**
Prettier Git diff checking was done with [a package](https://github.com/kandhavivekraj/git-changed-files#basebranch) which had 'master' as default branch, causing the prettifying process to fail as we switched to 'main'

Changes proposed in this pull request:

- set default to main
- change to new cypress e2e test folder 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
