### PR TITLE
Accordion element not showing correctly in breadcrumb docu

### DIFF
--- a/docs/navigation-advanced.md
+++ b/docs/navigation-advanced.md
@@ -471,8 +471,9 @@ In your custom code, you can choose any look and style for the breadcrumbs as we
       }
 ```
 
-<!-- accordion:start -->
 Below is an example of a simple `breadcrumbsConfig`:
+
+<!-- accordion:start -->
 
 ### Click to expand
 
@@ -503,8 +504,11 @@ navigation.breadcrumbs = {
       }
     };
 ```
+<!-- accordion:end -->
 
 Below is another example which uses UI5 Web Components breadcrumbs: 
+
+<!-- accordion:start -->
 
 ### Click to expand
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**

Changes proposed in this pull request:

- After merging #2416 , the accordion element is not showing correctly in breadcrumb documentation: 
<img width="1592" alt="Screenshot 2023-04-04 at 11 48 27" src="https://user-images.githubusercontent.com/49867570/229754707-54bd2646-091c-4828-af3a-d7d86d1b51cd.png">


There should be labels above the accordion element.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
