### PR TITLE
Removed old internet explorer logic

### DIFF
--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -83,18 +83,13 @@ class RoutingClass {
     // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#Browser_compatibility
     // https://developer.mozilla.org/en-US/docs/Web/API/Event#Browser_compatibility
     // https://developer.mozilla.org/en-US/docs/Web/API/Event/createEvent
-    let event;
-    if (GenericHelpers.isIE()) {
-      event = new Event('popstate', { bubbles: true, cancelable: true });
-    } else {
-      const eventDetail = {
-        detail: {
-          preventContextUpdate,
-          withoutSync: !navSync
-        }
-      };
-      event = new CustomEvent('popstate', eventDetail);
-    }
+    const eventDetail = {
+      detail: {
+        preventContextUpdate,
+        withoutSync: !navSync
+      }
+    };
+    const event = new CustomEvent('popstate', eventDetail);
 
     window.dispatchEvent(event);
   }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**
Removed the conditional statement that checks if the browser is Internet Explorer and always create a CustomEvent object with a custom detail property that includes preventContextUpdate and withoutSync properties. This removes the reliance on Internet Explorer-specific APIs and simplifies the code. This change should work in all modern browsers.

Changes proposed in this pull request:
- [x] Remove Internet Explorer-specific logic from popstate event creation

**Related issue(s)**

Fixes #3263 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
