### PR TITLE
Fix node version to 18.15.0

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'    
+          node-version: '18.15.0'    
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: ~/.cache

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/publish_cra.yml
+++ b/.github/workflows/publish_cra.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - run: bash ./scripts/npmPublish.sh cra-release

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/setupScripts.yml
+++ b/.github/workflows/setupScripts.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - run: |
           OUT=$(bash ./test/setuptests.sh @angular/cli 4200 http://localhost:4200/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/angular.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 4200" <<< "$OUT")
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - run: |
           OUT=$(bash ./test/setuptests.sh @vue/cli 8080 http://localhost:8080/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/vue.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 8080" <<< "$OUT")
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - run: |
           OUT=$(bash ./test/setuptests.sh 'react-cli react' 3000 http://localhost:3000/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/react.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 3000" <<< "$OUT")
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - run: |
           OUT=$(bash ./test/setuptests.sh @ui5/cli 8080 http://localhost:8080/index.html#/home https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/openui5.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 8080" <<< "$OUT")
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - run: |
           OUT=$(bash ./test/setuptests.sh ' ' 8080 http://localhost:8080/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/no-framework.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 8080" <<< "$OUT")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: |
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'    
+          node-version: '18.15.0'    
       - uses: actions/cache@v3
         with:
           path: |
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.15.0'
       - uses: actions/cache@v3
         with:
           path: |
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'       
+          node-version: '18.15.0'       
       - run: cd ./scripts && npm ci
       - run: bash ./scripts/docuCheck.sh
       


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**

Changes proposed in this pull request:

We set node 18 as Pipeline standard, and it picks the latest current LTS. But it seems some new node was released recently, and that causes an issue with the pipeline.

Failing for node 18.16.0
https://github.com/SAP/luigi/actions/runs/4753488852/jobs/8447292296#step:2:10

Succeding with node 18.15.0
https://github.com/SAP/luigi/actions/runs/4747489631/jobs/8432557852#step:2:10

This PR fixes the node version to 18.15.0 so we keep with a consistent node until we decide to upgrade