### PR TITLE
Check if showModalPathInUrl is defined

### DIFF
--- a/core/src/App.svelte
+++ b/core/src/App.svelte
@@ -1640,6 +1640,10 @@
       }
 
       if ('luigi.navigation.updateModalDataPath' === e.data.msg) {
+        if(!LuigiConfig.getConfigBooleanValue('routing.showModalPathInUrl')){
+          console.warn('"showModalPathInUrl" will be ignored. Property is not defined or not set to `true`.');
+          return;
+        }
         if (isSpecialIframe) {
           const route = GenericHelpers.addLeadingSlash(
             buildPath(
@@ -1954,8 +1958,8 @@
         nodepath={modalItem.mfModal.nodepath}
         modalIndex={index}
         on:close={() => closeModal(index, true)}
-        on:iframeCreated={(event) => modalIframeCreated(event, index)}
-        on:wcCreated={(event) => modalWCCreated(event, index)}
+        on:iframeCreated={event => modalIframeCreated(event, index)}
+        on:wcCreated={event => modalWCCreated(event, index)}
         {disableBackdrop}
       />
     {/if}

--- a/core/src/App.svelte
+++ b/core/src/App.svelte
@@ -1641,7 +1641,7 @@
 
       if ('luigi.navigation.updateModalDataPath' === e.data.msg) {
         if(!LuigiConfig.getConfigBooleanValue('routing.showModalPathInUrl')){
-          console.warn('"showModalPathInUrl" will be ignored. Property is not defined or not set to `true`.');
+          console.warn('Updating path of the modal ignored. Property "showModalPathInUrl" is not defined or not set to `true`.');
           return;
         }
         if (isSpecialIframe) {

--- a/core/src/App.svelte
+++ b/core/src/App.svelte
@@ -1641,7 +1641,6 @@
 
       if ('luigi.navigation.updateModalDataPath' === e.data.msg) {
         if(!LuigiConfig.getConfigBooleanValue('routing.showModalPathInUrl')){
-          console.warn('Updating path of the modal ignored. Property "showModalPathInUrl" is not defined or not set to `true`.');
           return;
         }
         if (isSpecialIframe) {


### PR DESCRIPTION
`updateModalDataPath`/`updateModalPathInternalNavigation` should only be possible if `showModalPathInUrl` is defined and set to `true`.
Fixes #3260 