### PR TITLE
Removed internet explorer logic

### DIFF
--- a/client/luigi-client.d.ts
+++ b/client/luigi-client.d.ts
@@ -738,6 +738,16 @@ export function setAnchor(anchor: String): void;
 export type setAnchor = (anchor: String) => void;
 
 /**
+ * Allows you to change node labels within the same {@link navigation-advanced.md#view-groups view group}, e.g. in your node config: `label: 'my Node {viewGroupData.vg1}'`.
+ * @param {Object} value a data object containing the view group name and desired label
+ * @memberof Lifecycle
+ * @example
+ * LuigiClient.setViewGroupData({'vg1':' Luigi rocks!'})
+ */
+export function setViewGroupData(value: Object): void;
+export type setViewGroupData = (value: Object) => void;
+
+/**
  * Read search query parameters which are sent from Luigi core
  * @memberof Lifecycle
  * @returns core search query parameters

--- a/core/src/UserSettingsDialog.svelte
+++ b/core/src/UserSettingsDialog.svelte
@@ -240,15 +240,9 @@
 
   function closest(element, selector, max) {
     if (element && max > 0) {
-      if (GenericHelpers.isIE()) {
-        return element.msMatchesSelector(selector)
-          ? element
-          : closest(element.parentNode, selector, max - 1);
-      } else {
-        return element.matches(selector)
-          ? element
-          : closest(element.parentNode, selector, max - 1);
-      }
+      return element.matches(selector)
+        ? element
+        : closest(element.parentNode, selector, max - 1);
     } else {
       return undefined;
     }

--- a/core/src/UserSettingsEditor.svelte
+++ b/core/src/UserSettingsEditor.svelte
@@ -33,15 +33,9 @@
 
   function closest(element, selector, max) {
     if (element && max > 0) {
-      if (GenericHelpers.isIE()) {
-        return element.msMatchesSelector(selector)
-          ? element
-          : closest(element.parentNode, selector, max - 1);
-      } else {
-        return element.matches(selector)
-          ? element
-          : closest(element.parentNode, selector, max - 1);
-      }
+      return element.matches(selector)
+        ? element
+        : closest(element.parentNode, selector, max - 1);
     } else {
       return undefined;
     }


### PR DESCRIPTION
**Description**
Removed internet explorer logic from UserSettingsEditor.svelte and UserSettingsDialog.svelte.

Changes proposed in this pull request:
- Refactoring UserSettingsEditor.svelte and UserSettingsDialog to remove internet explorer logic making the code simpler.

**Related issue(s)**
Fixes #3292
