### PR TITLE
Added helper method for calculating shellbar height

### DIFF
--- a/core/src/SplitView.svelte
+++ b/core/src/SplitView.svelte
@@ -195,7 +195,7 @@
     }
   }
   export function updateSizes() {
-    const shellbarHeight = LuigiElements.getShellbar().clientHeight;
+    const shellbarHeight = GenericHelpers.getShellbarHeight();
     SplitViewSvc.internalValues.innerHeight = GenericHelpers.getInnerHeight();
     SplitViewSvc.internalValues.rightContentHeight =
       SplitViewSvc.internalValues.innerHeight - shellbarHeight;

--- a/core/src/services/split-view.js
+++ b/core/src/services/split-view.js
@@ -168,7 +168,7 @@ class SplitViewSvcClass {
   calculateAndSetSplitViewValues(percentBottom, values) {
     const newBottom =
       parseInt(GenericHelpers.computePxFromPercent(values.rightContentHeight, 100 - percentBottom)) +
-      LuigiElements.getShellbar().clientHeight;
+      GenericHelpers.getShellbarHeight();
 
     this.splitViewValues = this.enforceTresholds(newBottom, values.innerHeight - newBottom, values);
   }

--- a/core/src/utilities/helpers/generic-helpers.js
+++ b/core/src/utilities/helpers/generic-helpers.js
@@ -298,7 +298,8 @@ class GenericHelpersClass {
   }
 
   /**
-   * Returns a new Object with the same object,   * without the keys that were given.
+   * Returns a new Object with the same object,   
+   * without the keys that were given.
    * References still stay.
    * Allows wildcard ending keys
    *

--- a/core/src/utilities/helpers/generic-helpers.js
+++ b/core/src/utilities/helpers/generic-helpers.js
@@ -252,7 +252,14 @@ class GenericHelpersClass {
   }
 
   getContentAreaHeight /* istanbul ignore next */() {
-    return this.getInnerHeight() - LuigiElements.getShellbar().clientHeight;
+    const contentAreaHeight = this.getInnerHeight() - this.getShellbarHeight();
+    return contentAreaHeight;
+  }
+
+  getShellbarHeight() {
+    const shellBar = LuigiElements.getShellbar() || {};
+    const shellBarHeight = shellBar.clientHeight || 0;
+    return shellBarHeight;
   }
 
   computePxFromPercent(fullPixels, requestedPercent) {
@@ -285,8 +292,7 @@ class GenericHelpersClass {
   }
 
   /**
-   * Returns a new Object with the same object,
-   * without the keys that were given.
+   * Returns a new Object with the same object,   * without the keys that were given.
    * References still stay.
    * Allows wildcard ending keys
    *

--- a/core/src/utilities/helpers/generic-helpers.js
+++ b/core/src/utilities/helpers/generic-helpers.js
@@ -256,6 +256,12 @@ class GenericHelpersClass {
     return contentAreaHeight;
   }
 
+  /**
+   * Returns the height of the shellbar component.
+   * This is important for calculating the height of available area
+   * for displaying content. If the shellbar component is not present, returns 0.
+   * @returns {number} height of the shellbar component
+   */
   getShellbarHeight() {
     const shellBar = LuigiElements.getShellbar() || {};
     const shellBarHeight = shellBar.clientHeight || 0;

--- a/core/test/services/split-view.spec.js
+++ b/core/test/services/split-view.spec.js
@@ -162,9 +162,7 @@ describe('SplitViewSvc', () => {
       };
 
       const shellbarHeight = 30;
-      LuigiElements.getShellbar.returns({
-        clientHeight: shellbarHeight
-      });
+      GenericHelpers.getShellbarHeight.returns(shellbarHeight);
 
       GenericHelpers.computePxFromPercent.onFirstCall().returns(400); // 40% of 1000px
 

--- a/core/test/utilities/helpers/generic-helpers.spec.js
+++ b/core/test/utilities/helpers/generic-helpers.spec.js
@@ -2,6 +2,7 @@ const chai = require('chai');
 const assert = chai.assert;
 const sinon = require('sinon');
 import { LuigiConfig } from '../../../src/core-api';
+import { LuigiElements } from '../../../src/core-api';
 import { GenericHelpers } from '../../../src/utilities/helpers';
 
 describe('Generic-helpers', () => {
@@ -186,6 +187,34 @@ describe('Generic-helpers', () => {
     it('experimental feature NOT configured and no console warn', () => {
       assert.equal(GenericHelpers.requestExperimentalFeature('tets', false), false);
       sinon.assert.neverCalledWith(console.warn);
+    });
+  });
+
+  describe('get shellbar height', () => {
+    beforeEach(() => {
+      sinon.stub(LuigiElements, 'getShellbar');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('shellbar is present', () => {
+      const shellbarHeight = 30;
+      LuigiElements.getShellbar.returns({
+        clientHeight: shellbarHeight
+      });
+      assert.equal(GenericHelpers.getShellbarHeight(), shellbarHeight);
+    });
+
+    it('shellbar is not present', () => {
+      LuigiElements.getShellbar.returns(undefined);
+      assert.equal(GenericHelpers.getShellbarHeight(), 0);
+    });
+
+    it('shellbar is present, no clientHeight', () => {
+      LuigiElements.getShellbar.returns({});
+      assert.equal(GenericHelpers.getShellbarHeight(), 0);
     });
   });
 });


### PR DESCRIPTION

**Description**
Added helper method `getShellbarHeight()` for calculating the height of the `shellbar`; It also includes logic for when the `shellbar` is not present, e.g. when one sets **settings.header.disabled** to `true`.
Changes proposed in this pull request:
- Add a helper method under `GenericHelpersClass` called `getShellbarHeight()` which returns the `clientHeight` property of the HTML element, with the class `luigi-shellbar-wrapper`, if present; 0 otherwise.
- Change the `getContentAreaHeight` method in the `GenericHelperClass` to use this new helper method for getting the height of the `shellbar`.
- Change the `calculateAndSetSplitViewValues` method in the `SplitViewSvcClass` to use this new helper method for getting the height of the `shellbar`
- change the `updateSizes` method in `SplitView.svelte` to use this new helper method for getting the height of the `shellbar`

**Related issue(s)**
Fixes #3266
