### PR TITLE
changed configChanged scope for vgdata

### DIFF
--- a/core/src/App.svelte
+++ b/core/src/App.svelte
@@ -1815,7 +1815,7 @@
         if (vg) {
           const vgSettings = Iframe.getViewGroupSettings(vg);
           vgSettings._liveCustomData = vgData.data;
-          LuigiConfig.configChanged('navigation.nodes');
+          LuigiConfig.configChanged('navigation.viewgroupdata');
         }
       }
     });

--- a/core/src/navigation/LeftNav.svelte
+++ b/core/src/navigation/LeftNav.svelte
@@ -235,6 +235,14 @@
       ['settings.footer']
     );
 
+    StateHelpers.doOnStoreChange(
+      store,
+      () => {
+        setLeftNavData();
+      },
+      ['navigation.viewgroupdata']
+    );
+
     let stateArr = SemiCollapsibleNavigation.initial();
     isSemiCollapsed = stateArr.isSemiCollapsed;
     semiCollapsible = stateArr.semiCollapsible;

--- a/core/src/navigation/TabNav.svelte
+++ b/core/src/navigation/TabNav.svelte
@@ -1,7 +1,7 @@
 <script>
   import { afterUpdate, beforeUpdate, createEventDispatcher, onMount, getContext, onDestroy } from 'svelte';
   import { Navigation } from './services/navigation';
-  import { NavigationHelpers, RoutingHelpers } from '../utilities/helpers';
+  import { NavigationHelpers, RoutingHelpers, StateHelpers } from '../utilities/helpers';
   import { LuigiConfig } from '../core-api';
   
   import TabHeader from './TabHeader.svelte'; 
@@ -19,6 +19,7 @@
   export let resizeTabNavToggle;
   let previousResizeTabNavToggle;
   let getTranslation = getContext('getTranslation');
+  let store = getContext('store');
   let resizeObserver;
 
   //TODO refactor
@@ -150,6 +151,13 @@
   onMount(() => {
     hideNavComponent = LuigiConfig.getConfigBooleanValue('settings.hideNavigation');
     handleHorizontalNavHeightChange();
+    StateHelpers.doOnStoreChange(
+      store,
+      () => {
+        setTabNavData();
+      },
+      ['navigation.viewgroupdata']
+    );
   });
 
   onDestroy(() => {

--- a/core/src/navigation/TopNav.svelte
+++ b/core/src/navigation/TopNav.svelte
@@ -135,6 +135,14 @@
       ['navigation']
     );
 
+    StateHelpers.doOnStoreChange(
+      store,
+      () => {
+        setTopNavData();
+      },
+      ['navigation.viewgroupdata']
+    );
+
     EventListenerHelpers.addEventListener('message', (e) => {
       if ('luigi.navigation.update-badge-counters' === e.data.msg) {
         setTopNavData();


### PR DESCRIPTION
the previous update scope 'navigation.nodes' was too coarse, leading to refresh full micro frontend views und some conditions (e.g. when opened as modal).
This solution introduces a dedicated vgdata update scope with only relevant components listening.