### PR TITLE
Fix getContextAsync in client lib for angular

### DIFF
--- a/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts
+++ b/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts
@@ -36,7 +36,7 @@ export class LuigiContextServiceImpl implements LuigiContextService {
    */
   public getContextAsync(): Promise<Context> {
     return new Promise<Context>((resolve, reject) => {
-      if (this.isObject(this.getContext()) && Object.keys(this.getContext()).length === 0) {
+      if (this.isObject(this.getContext()) && Object.keys(this.getContext()).length > 0) {
         resolve(this.getContext());
       } else {
         this.contextObservable()

--- a/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts
+++ b/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts
@@ -36,7 +36,7 @@ export class LuigiContextServiceImpl implements LuigiContextService {
    */
   public getContextAsync(): Promise<Context> {
     return new Promise<Context>((resolve, reject) => {
-      if (this.getContext()) {
+      if (this.isObject(this.getContext()) && Object.keys(this.getContext()).length === 0) {
         resolve(this.getContext());
       } else {
         this.contextObservable()
@@ -46,6 +46,15 @@ export class LuigiContextServiceImpl implements LuigiContextService {
           });
       }
     });
+  }
+
+  /**
+   * Checks if input is an object.
+   * @param objectToCheck mixed
+   * @returns {boolean}
+   */
+  private isObject(objectToCheck: any) {
+    return !!(objectToCheck && typeof objectToCheck === 'object' && !Array.isArray(objectToCheck));
   }
 
   /**


### PR DESCRIPTION
Since getContext returns an empty object if no context is defined instead of null/undefined we need to check for empty context object in getContextAsync.