### PR TITLE
Add name to root package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-   "name": "sapluigi",
+   "name": "luigi",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
+         "name": "luigi",
          "devDependencies": {
             "@starptech/prettyhtml": "^0.10.0",
             "@typescript-eslint/eslint-plugin": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+   "name": "luigi",
    "private": true,
    "scripts": {
       "test:compatibility": "./scripts/testCompatibility.sh",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**

Changes proposed in this pull request:

- When running `npm install` in the root folder (e.g. as instructed in CONTRIBUTING.md), the `name` properties in package-lock.json are changed from `sapluigi` to the name of the local folder of the repository. If the repository was cloned with default settings, that folder name will be `luigi`. The background is that npm will fall back to the folder name if no package name is given in package.json.

  This change sets the `name` property in package.json to `luigi` to avoid this behavior.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
None