### PR TITLE
Cypress wait call removal, final change

### DIFF
--- a/test/e2e-test-application/cypress/e2e/test2/1-angular/external-micro-frontend.cy.js
+++ b/test/e2e-test-application/cypress/e2e/test2/1-angular/external-micro-frontend.cy.js
@@ -2,12 +2,14 @@ describe('Navigation', () => {
   beforeEach(() => {
     cy.visitLoggedIn('/');
   });
+
   describe('Normal navigating', () => {
     it('Check if external micro frontend is available and an alert will be shown.', () => {
       cy.visit('/projects/pr1/externalmf');
-      cy.wait(5000);
-      cy.get('[data-testid=luigi-alert]').contains('This is just a test alert for external micro frontend.');
-      cy.get('[data-testid=luigi-alert]').should('have.class', 'fd-message-strip--success');
+      cy.get('[data-testid=luigi-alert]', { timeout: 5000 }).should('have.class', 'fd-message-strip--success');
+      cy.get('[data-testid=luigi-alert]', { timeout: 5000 }).contains(
+        'This is just a test alert for external micro frontend.'
+      );
     });
   });
 });

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
@@ -1,17 +1,10 @@
 import defaultLuigiConfig from '../../configs/default';
-import { cloneDeep } from 'lodash';
 require('cypress-plugin-tab');
 describe('JS-TEST-APP 4', () => {
-  const localRetries = {
-    retries: {
-      runMode: 4,
-      openMode: 4
-    }
-  };
   describe('AY11', () => {
     let newConfig;
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.tag = 'user-settings-dialog';
       newConfig.userSettings = {
         userSettingGroups: {

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-history-for-modals.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-history-for-modals.cy.js
@@ -1,5 +1,4 @@
 import defaultLuigiConfig from '../../configs/default';
-import { cloneDeep } from 'lodash';
 
 describe('JS-TEST-APP', () => {
   const clickingAroundInNavigation = () => {
@@ -74,7 +73,7 @@ describe('JS-TEST-APP', () => {
       let newConfig;
 
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.routing.showModalPathInUrl = true;
         newConfig.routing.useHashRouting = false;
         newConfig.tag = 'js-test-app-history-handling-modals-1';
@@ -189,7 +188,7 @@ describe('JS-TEST-APP', () => {
       let newConfig;
 
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.routing.showModalPathInUrl = true;
         newConfig.routing.useHashRouting = true;
         newConfig.tag = 'js-test-app-history-handling-modals-2';

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-history-for-modals.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-history-for-modals.cy.js
@@ -2,12 +2,6 @@ import defaultLuigiConfig from '../../configs/default';
 import { cloneDeep } from 'lodash';
 
 describe('JS-TEST-APP', () => {
-  const localRetries = {
-    retries: {
-      runMode: 4,
-      openMode: 4
-    }
-  };
   const clickingAroundInNavigation = () => {
     cy.get('.fd-app__sidebar')
       .contains('Section one')
@@ -47,17 +41,13 @@ describe('JS-TEST-APP', () => {
   const expectedPathAfterForward = path => {
     cy.go('forward');
     cy.expectPathToBe(path);
-    cy.location().should(location => {
-      expect(location.search).to.eq('');
-    });
+    cy.location('search').should('eq', '');
   };
 
   const expectedPathAfterBack = path => {
-    cy.go(-1);
+    cy.go('back');
     cy.expectPathToBe(path);
-    cy.location().should(location => {
-      expect(location.search).to.eq('');
-    });
+    cy.location('search').should('eq', '');
   };
 
   const openModal = hash => {
@@ -68,9 +58,7 @@ describe('JS-TEST-APP', () => {
       cy.expectPathToBe('/home?modal=' + encodeURIComponent('/home/modalMf'));
     } else {
       cy.expectPathToBe('/home');
-      cy.location().then(location => {
-        expect(location.search).to.eq('?modal=' + encodeURIComponent('/home/modalMf'));
-      });
+      cy.location('search').should('eq', `?modal=${encodeURIComponent('/home/modalMf')}`);
     }
   };
 
@@ -82,6 +70,7 @@ describe('JS-TEST-APP', () => {
   describe('History handling for modals', () => {
     describe('Path routing, history handling for a single modal', () => {
       let newConfig;
+
       beforeEach(() => {
         newConfig = cloneDeep(defaultLuigiConfig);
         newConfig.routing.showModalPathInUrl = true;
@@ -95,6 +84,7 @@ describe('JS-TEST-APP', () => {
           openNodeInModal: true
         });
       });
+
       it('Path routing, open modal and close via [x]', () => {
         cy.vistTestAppPathRouting('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-1"]');
@@ -103,6 +93,7 @@ describe('JS-TEST-APP', () => {
         expectedPathAfterForward('/home');
         expectedPathAfterBack('/home');
       });
+
       it('Path routing, visit luigi with modal data', () => {
         cy.vistTestAppPathRouting('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-1"]');
@@ -113,6 +104,7 @@ describe('JS-TEST-APP', () => {
           expectedPathAfterBack('/home');
         });
       });
+
       it('Path routing, navigate few times and than open modal and close via [x]', () => {
         cy.vistTestAppPathRouting('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-1"]');
@@ -122,6 +114,7 @@ describe('JS-TEST-APP', () => {
         expectedPathAfterBack('/home/two');
         expectedPathAfterForward('/home');
       });
+
       it('Path routing, open modal, navigate through a wizard and close the modal via [X]', () => {
         newConfig.navigation.nodes[0].children.push({
           pathSegment: 'usersettings',
@@ -135,6 +128,7 @@ describe('JS-TEST-APP', () => {
         closeModal();
         expectedPathAfterBack('blank');
       });
+
       it('Path routing, open modal and close via browswer back', () => {
         cy.vistTestAppPathRouting('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-1"]');
@@ -148,6 +142,7 @@ describe('JS-TEST-APP', () => {
         cy.expectPathToBe('/home');
         cy.go('back');
       });
+
       it('Path routing, navigate few times and than open modal and close via browser back', () => {
         cy.vistTestAppPathRouting('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-1"]');
@@ -159,6 +154,7 @@ describe('JS-TEST-APP', () => {
         cy.go('back');
         cy.expectPathToBe('/home');
       });
+
       it('Path routing, open modal, navigate through a wizard and close the modal via browser back', () => {
         newConfig.navigation.nodes[0].children.push({
           pathSegment: 'usersettings',
@@ -175,6 +171,7 @@ describe('JS-TEST-APP', () => {
         cy.go('back');
         cy.expectPathToBe('/home');
       });
+
       it('Path routing, open and close and open and close the modal', () => {
         cy.vistTestAppPathRouting('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-1"]');
@@ -185,8 +182,10 @@ describe('JS-TEST-APP', () => {
         cy.expectPathToBe('/home');
       });
     });
+    
     describe('Hash routing, history handling for a single modal', () => {
       let newConfig;
+
       beforeEach(() => {
         newConfig = cloneDeep(defaultLuigiConfig);
         newConfig.routing.showModalPathInUrl = true;
@@ -199,6 +198,7 @@ describe('JS-TEST-APP', () => {
           openNodeInModal: true
         });
       });
+      
       it('Hash routing, open modal and close via [X]', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-2"]');
@@ -207,6 +207,7 @@ describe('JS-TEST-APP', () => {
         expectedPathAfterForward('/home');
         expectedPathAfterBack('/home');
       });
+
       it('Hash routing, visit luigi with modal data', () => {
         cy.visitTestApp('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-2"]');
@@ -218,6 +219,7 @@ describe('JS-TEST-APP', () => {
           expectedPathAfterBack('/home');
         });
       });
+
       it('Hash routing, visit luigi with modal data and search params', () => {
         cy.visitTestApp('/home?~test=tets&modal=' + encodeURIComponent('/home/modalMf'), newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-2"]');
@@ -226,6 +228,7 @@ describe('JS-TEST-APP', () => {
         cy.expectPathToBe('/home?%7Etest=tets');
         expectedPathAfterBack('/home?%7Etest=tets');
       });
+
       it('Hash routing, navigate few times and than open modal and close via [X]', () => {
         cy.visitTestApp('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-2"]');
@@ -235,6 +238,7 @@ describe('JS-TEST-APP', () => {
         expectedPathAfterBack('/home/two');
         expectedPathAfterForward('/home');
       });
+
       it('Hash routing, open modal, navigate through a wizard and close the modal via [x]', () => {
         newConfig.navigation.nodes[0].children.push({
           pathSegment: 'usersettings',
@@ -249,6 +253,7 @@ describe('JS-TEST-APP', () => {
         expectedPathAfterForward('/home');
         expectedPathAfterBack('/home');
       });
+
       it('Hash routing, open modal and close via browswer back', () => {
         cy.visitTestApp('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-2"]');
@@ -258,6 +263,7 @@ describe('JS-TEST-APP', () => {
         cy.go('forward');
         cy.expectPathToBe('/home');
       });
+
       it('Hash routing, navigate few times and than open modal and close via browser back', () => {
         cy.visitTestApp('', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-2"]');
@@ -269,6 +275,7 @@ describe('JS-TEST-APP', () => {
         cy.go('back');
         cy.expectPathToBe('/home');
       });
+
       it('Hash routing, open modal, navigate through a wizard and close the modal via browser back', () => {
         newConfig.navigation.nodes[0].children.push({
           pathSegment: 'usersettings',

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-history-for-modals.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-history-for-modals.cy.js
@@ -64,6 +64,8 @@ describe('JS-TEST-APP', () => {
 
   const closeModal = () => {
     cy.get('.lui-modal-index-0 .fd-button').click({ force: true });
+    // We were not able to avoid this wait due to random timing issues
+    // with navigation, popstate events and the modal closing.
     cy.wait(1000);
   };
 
@@ -182,7 +184,7 @@ describe('JS-TEST-APP', () => {
         cy.expectPathToBe('/home');
       });
     });
-    
+
     describe('Hash routing, history handling for a single modal', () => {
       let newConfig;
 
@@ -198,7 +200,7 @@ describe('JS-TEST-APP', () => {
           openNodeInModal: true
         });
       });
-      
+
       it('Hash routing, open modal and close via [X]', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('#app[configversion="js-test-app-history-handling-modals-2"]');

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-navigation.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-navigation.cy.js
@@ -1,5 +1,4 @@
 import defaultLuigiConfig from '../../configs/default';
-import { cloneDeep } from 'lodash';
 
 describe('JS-TEST-APP', () => {
   const localRetries = {
@@ -8,13 +7,17 @@ describe('JS-TEST-APP', () => {
       openMode: 4
     }
   };
+
   describe('Navigation', () => {
+
     describe('Core api navigation test', () => {
       let newConfig;
+
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.tag = 'js-test-app-core-api-nav-test';
       });
+
       it('Core API navigate and open and close modal', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('#app[configversion="js-test-app-core-api-nav-test"]');
@@ -36,47 +39,50 @@ describe('JS-TEST-APP', () => {
           .click();
         cy.expectPathToBe('/home/two');
       });
+
       it('Open modal via core api with "fullscreen"', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('[configversion="js-test-app-core-api-nav-test"]');
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { size: 'fullscreen' });
         });
-        cy.get('.lui-modal-mf').should('exist');
-        cy.get('.lui-modal-mf').should('have.class', 'lui-modal-fullscreen');
-        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:100vw;height:100vh;');
+        cy.get('.lui-modal-mf')
+          .should('have.class', 'lui-modal-fullscreen')
+          .and('have.attr', 'style', 'width:100vw;height:100vh;');
         cy.get('[aria-label="close"]').click();
       });
+
       it('Open modal via core api with "px"', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('[configversion="js-test-app-core-api-nav-test"]');
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '500px', height: '500px' });
         });
-        cy.get('.lui-modal-mf').should('exist');
         cy.get('.lui-modal-mf')
           .should('have.css', 'width', '500px')
           .and('have.css', 'height', '500px');
         cy.get('[aria-label="close"]').click();
       });
+
       it('Open modal via core api with "%"', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('[configversion="js-test-app-core-api-nav-test"]');
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '20%', height: '40%' });
         });
-        cy.get('.lui-modal-mf').should('exist');
-        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:20%;height:40%;');
+        cy.get('.lui-modal-mf')
+          .should('have.attr', 'style', 'width:20%;height:40%;');
         cy.get('[aria-label="close"]').click();
       });
+
       it('Open modal via core api with "rem"', localRetries, () => {
         cy.visitTestApp('/', newConfig);
         cy.get('[configversion="js-test-app-core-api-nav-test"]');
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '50rem', height: '70rem' });
         });
-        cy.get('.lui-modal-mf').should('exist');
-        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:50rem;height:70rem;');
+        cy.get('.lui-modal-mf')
+          .should('have.attr', 'style', 'width:50rem;height:70rem;');
         cy.get('[aria-label="close"]').click();
       });
 
@@ -86,10 +92,11 @@ describe('JS-TEST-APP', () => {
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '34psx', height: '70rm' });
         });
-        cy.get('.lui-modal-mf').should('exist');
-        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:80%;height:80%;');
+        cy.get('.lui-modal-mf')
+          .should('have.attr', 'style', 'width:80%;height:80%;');
         cy.get('[aria-label="close"]').click();
       });
+
       it('Update modal settings', () => {
         newConfig.routing.showModalPathInUrl = true;
         cy.visitTestApp('/', newConfig);
@@ -97,28 +104,33 @@ describe('JS-TEST-APP', () => {
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '50rem', height: '70rem' });
         });
-        cy.get('.lui-modal-mf').should('exist');
-        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:50rem;height:70rem;');
-        cy.url().should('include', 'width%22%3A%2250rem');
-        cy.url().should('include', 'height%22%3A%2270rem');
-        cy.url().should('not.contain', '/title%22%3A%22test/');
+        cy.get('.lui-modal-mf')
+          .should('have.attr', 'style', 'width:50rem;height:70rem;');
+        cy.url()
+          .should('include', 'width%22%3A%2250rem')
+          .and('include', 'height%22%3A%2270rem')
+          .and('not.contain', '/title%22%3A%22test/');
         cy.getIframeBody({}, 0, '.iframeModalCtn').then(result => {
           cy.wrap(result)
             .contains('updateModalSettings')
             .click();
-          cy.url().should('include', 'width%22%3A%2250rem');
-          cy.url().should('include', 'height%22%3A%2270rem');
-          cy.url().should('include', 'title%22%3A%22test');
+          cy.url()
+            .should('include', 'width%22%3A%2250rem')
+            .and('include', 'height%22%3A%2270rem')
+            .and('include', 'title%22%3A%22test');
         });
       });
     });
+
     describe('Normal navigation', () => {
       let newConfig;
+
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.navigation.nodes[0].viewUrl = null;
         newConfig.tag = 'normal-navigation';
       });
+
       it('defaultChildNode', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('#app[configversion="normal-navigation"]');
@@ -127,6 +139,7 @@ describe('JS-TEST-APP', () => {
           cy.expectPathToBe('/home/two');
         });
       });
+
       it('hideShellbar', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('#app[configversion="normal-navigation"]');
@@ -138,10 +151,12 @@ describe('JS-TEST-APP', () => {
         cy.contains('.fd-shellbar').should('not.exist');
       });
     });
+
     describe('Tooltext for category button', () => {
       let newConfig;
+
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.navigation.nodes[0].children[0].category = {
           label: 'Test Category',
           collapsible: true,
@@ -150,6 +165,7 @@ describe('JS-TEST-APP', () => {
         };
         newConfig.tag = 'tooltip-test';
       });
+
       it('Tooltip for expand/collapse button', () => {
         cy.visitTestApp('/', newConfig);
         cy.get('#app[configversion="tooltip-test"]');
@@ -160,6 +176,7 @@ describe('JS-TEST-APP', () => {
           .click();
         cy.get('.lui-collapsible-item button').should('have.attr', 'title', 'Collapse test category');
       });
+
       it('Tooltip for expand button not defined', () => {
         delete newConfig.navigation.nodes[0].children[0].category.titleExpandButton;
         newConfig.tag = 'tooltip-test-2';
@@ -172,6 +189,7 @@ describe('JS-TEST-APP', () => {
           .click();
         cy.get('.lui-collapsible-item button').should('have.attr', 'title', 'Collapse test category');
       });
+
       it('Tooltip for collapse button not defined', () => {
         delete newConfig.navigation.nodes[0].children[0].category.titleCollapseButton;
         newConfig.tag = 'tooltip-test-3';
@@ -184,6 +202,7 @@ describe('JS-TEST-APP', () => {
           .click();
         cy.get('.lui-collapsible-item button').should('not.have.attr', 'title');
       });
+
       it('Default tooltip for collapse and expand button only applied if it is not configured on category itself', () => {
         newConfig.navigation.defaults = {
           category: {
@@ -203,34 +222,13 @@ describe('JS-TEST-APP', () => {
         cy.get('.lui-collapsible-item button').should('have.attr', 'title', 'Default collapse tooltip');
       });
     });
+
     describe('Viewgroup live settings', () => {
       let newConfig;
       let $iframeBody;
-      const additionalChildren = [
-        {
-          pathSegment: 'mfe1',
-          label: 'MFE 1 {viewGroupData.foo}',
-          icon: 'home',
-          viewUrl: 'mfe.html#1',
-          viewGroup: 'vg1'
-        },
-        {
-          pathSegment: 'mfe2',
-          label: 'MFE 2 {viewGroupData.foo}',
-          icon: 'home',
-          viewUrl: 'mfe.html#2',
-          viewGroup: 'vg2'
-        },
-        {
-          pathSegment: 'mfe3',
-          label: 'MFE 3 {viewGroupData.bar}',
-          icon: 'home',
-          viewUrl: 'mfe.html#3',
-          viewGroup: 'vg2'
-        }
-      ];
+
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.tag = 'viewgroup-live-settings';
         newConfig.navigation['viewGroupSettings'] = {
           vg1: {},
@@ -278,10 +276,12 @@ describe('JS-TEST-APP', () => {
       });
     });
   });
+
   describe('ContextSwitcher', () => {
     let newConfig;
+
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.navigation.nodes.push({
         hideFromNav: true,
         pathSegment: 'environments',
@@ -324,6 +324,7 @@ describe('JS-TEST-APP', () => {
         }
       };
     });
+
     it('custom selected option renderer', () => {
       cy.visitTestApp('/', newConfig);
 
@@ -369,10 +370,12 @@ describe('JS-TEST-APP', () => {
       cy.get('#context_menu_middle .is-selected').should('have.length', 1);
     });
   });
+
   describe('virtualTree with fromVirtualTreeRoot', localRetries, () => {
     let newConfig;
+
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.navigation.nodes.push({
         pathSegment: 'virtual',
         label: 'Virtual',
@@ -387,6 +390,7 @@ describe('JS-TEST-APP', () => {
         }
       });
     });
+
     it('navigate', localRetries, () => {
       cy.visitTestApp('/virtual', newConfig);
       let $iframeBody;
@@ -401,12 +405,15 @@ describe('JS-TEST-APP', () => {
       cy.expectPathToBe('/virtual/this/is/a/tree');
     });
   });
+
   describe('Unload and load Luigi', () => {
     let newConfig;
+
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       cy.visitTestApp('/home/two', newConfig);
     });
+
     it('Core API unload', () => {
       let config;
       cy.window().then(win => {
@@ -435,6 +442,7 @@ describe('JS-TEST-APP', () => {
       cy.get('.fd-shellbar').should('be.visible');
     });
   });
+
   describe('Show-hide of Logout & Login Buttons', () => {
     const loginLink = () => {
       return cy.get('[data-testid="login-btn"]');
@@ -442,10 +450,12 @@ describe('JS-TEST-APP', () => {
     const logoutLink = () => {
       return cy.get('[data-testid="logout-btn"]');
     };
+
     describe('No Auth', () => {
       let newConfig;
+
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.auth = undefined;
         newConfig.navigation.profile = {
           logout: {
@@ -454,6 +464,7 @@ describe('JS-TEST-APP', () => {
           }
         };
       });
+
       it('Static profile, and logging out with customLogoutFn', () => {
         cy.visitTestApp('/home/two', newConfig);
         cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
@@ -483,10 +494,12 @@ describe('JS-TEST-APP', () => {
         });
       });
     });
+
     describe('With Auth', () => {
       let newConfig;
+
       beforeEach(() => {
-        newConfig = cloneDeep(defaultLuigiConfig);
+        newConfig = structuredClone(defaultLuigiConfig);
         newConfig.auth = {
           use: 'myOAuth2',
           myOAuth2: {
@@ -576,7 +589,7 @@ describe('JS-TEST-APP', () => {
         newConfig.navigation.profile = undefined;
         newConfig.auth.disableAutoLogin = true;
         newConfig.tag = 'loginlogoutcoreapi';
-        let cfg = cloneDeep(newConfig);
+        let cfg = structuredClone(newConfig);
         cy.visitTestApp('/', cfg);
 
         cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
@@ -591,7 +604,7 @@ describe('JS-TEST-APP', () => {
 
         cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
         logoutLink().should('exist');
-        cfg = cloneDeep(newConfig);
+        cfg = structuredClone(newConfig);
         cy.visit('http://localhost:4500/auth/logout.html');
         cfg.auth.myOAuth2.idpProvider = 'LuigiAuthOAuth2';
 

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-navigation.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-navigation.cy.js
@@ -9,7 +9,6 @@ describe('JS-TEST-APP', () => {
   };
 
   describe('Navigation', () => {
-
     describe('Core api navigation test', () => {
       let newConfig;
 
@@ -70,8 +69,7 @@ describe('JS-TEST-APP', () => {
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '20%', height: '40%' });
         });
-        cy.get('.lui-modal-mf')
-          .should('have.attr', 'style', 'width:20%;height:40%;');
+        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:20%;height:40%;');
         cy.get('[aria-label="close"]').click();
       });
 
@@ -81,8 +79,7 @@ describe('JS-TEST-APP', () => {
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '50rem', height: '70rem' });
         });
-        cy.get('.lui-modal-mf')
-          .should('have.attr', 'style', 'width:50rem;height:70rem;');
+        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:50rem;height:70rem;');
         cy.get('[aria-label="close"]').click();
       });
 
@@ -92,8 +89,7 @@ describe('JS-TEST-APP', () => {
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '34psx', height: '70rm' });
         });
-        cy.get('.lui-modal-mf')
-          .should('have.attr', 'style', 'width:80%;height:80%;');
+        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:80%;height:80%;');
         cy.get('[aria-label="close"]').click();
       });
 
@@ -104,8 +100,7 @@ describe('JS-TEST-APP', () => {
         cy.window().then(win => {
           win.Luigi.navigation().openAsModal('/home/two', { width: '50rem', height: '70rem' });
         });
-        cy.get('.lui-modal-mf')
-          .should('have.attr', 'style', 'width:50rem;height:70rem;');
+        cy.get('.lui-modal-mf').should('have.attr', 'style', 'width:50rem;height:70rem;');
         cy.url()
           .should('include', 'width%22%3A%2250rem')
           .and('include', 'height%22%3A%2270rem')

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-node-params.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-node-params.cy.js
@@ -1,5 +1,4 @@
 import defaultLuigiConfig from '../../configs/default';
-import { cloneDeep } from 'lodash';
 
 describe('JS-TEST-APP 3', () => {
   const localRetries = {
@@ -8,10 +7,12 @@ describe('JS-TEST-APP 3', () => {
       openMode: 4
     }
   };
+
   describe('LuigiClient add and delete node and search params', () => {
     let newConfig;
+
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.routing.useHashRouting = true;
       const node = {
         pathSegment: 'mynode',
@@ -54,6 +55,7 @@ describe('JS-TEST-APP 3', () => {
       });
       cy.expectPathToBe('/home/mynode?luigi=rocks');
     });
+
     it('Add and delete node params hash routing enabled', () => {
       cy.visitTestApp('/home/mynode', newConfig);
       cy.getIframeBody().then($body => {
@@ -79,8 +81,9 @@ describe('JS-TEST-APP 3', () => {
 
   describe('LuigiClient add and delete node and search paramstest', () => {
     let newConfig;
+
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.routing.useHashRouting = false;
       const node = {
         pathSegment: 'mynode',

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
@@ -1,5 +1,4 @@
 import defaultLuigiConfig from '../../configs/default';
-import { cloneDeep } from 'lodash';
 
 describe('JS-TEST-APP 2', () => {
   const localRetries = {
@@ -11,7 +10,7 @@ describe('JS-TEST-APP 2', () => {
   describe('Theming', () => {
     let newConfig;
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.settings.theming = {
         themes: () => [
           { id: 'light', name: 'Fiori3 Light' },
@@ -87,7 +86,7 @@ describe('JS-TEST-APP 2', () => {
     let newConfig;
 
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.settings.responsiveNavigation = 'semiCollapsible';
       // cy.window().then(win => {
       //   win.Luigi.configChanged('settings');
@@ -124,7 +123,7 @@ describe('JS-TEST-APP 2', () => {
     let newConfig;
 
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.settings.responsiveNavigation = 'Fiori3';
       cy.visitTestApp('/', newConfig);
       cy.window().then(win => {
@@ -164,7 +163,7 @@ describe('JS-TEST-APP 2', () => {
   describe('User settings dialog', () => {
     let newConfig;
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.tag = 'user-settings-dialog';
       newConfig.userSettings = {
         userSettingGroups: {
@@ -288,7 +287,7 @@ describe('JS-TEST-APP 2', () => {
   describe('Bookmarkable micro frontends', () => {
     let newConfig;
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
     });
 
     it('Hash routing with showModalPathInUrl enabled and custom modalPathParam and node params', () => {
@@ -345,7 +344,7 @@ describe('JS-TEST-APP 2', () => {
   describe('GlobalSearchCentered', () => {
     let newConfig;
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.globalSearch = {
         searchFieldCentered: true,
         searchProvider: {}
@@ -414,7 +413,7 @@ describe('JS-TEST-APP 2', () => {
     };
 
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.settings = {
         experimental: {
           navHeader: true,
@@ -532,7 +531,7 @@ describe('JS-TEST-APP 2', () => {
   describe('Encoded ViewURL Search Params with Decorators', () => {
     let newConfig;
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.tag = 'encodeViewURL';
       newConfig.settings.theming = {
         defaultTheme: 'light',
@@ -588,7 +587,7 @@ describe('JS-TEST-APP 2', () => {
   describe('Transfer theme vars to client', () => {
     let newConfig;
     beforeEach(() => {
-      newConfig = cloneDeep(defaultLuigiConfig);
+      newConfig = structuredClone(defaultLuigiConfig);
       newConfig.tag = 'transferThemeVars';
       newConfig.settings.theming = {
         defaultTheme: 'light',

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
@@ -55,7 +55,7 @@ describe('JS-TEST-APP 2', () => {
       };
       cy.visitTestApp('/', newConfig);
 
-      cy.get('iframe').then(ifr => {
+      cy.get('iframe').should(ifr => {
         const url = new URL(ifr.attr('src'));
         expect(`${url.pathname}${url.search}${url.hash}`).to.equal(
           '/examples/microfrontends/multipurpose.html?sap-theme=light'
@@ -73,7 +73,7 @@ describe('JS-TEST-APP 2', () => {
       };
       cy.visitTestApp('/', newConfig);
 
-      cy.get('iframe').then(ifr => {
+      cy.get('iframe').should(ifr => {
         const url = new URL(ifr.attr('src'));
         expect(`${url.pathname}${url.search}${url.hash}`).to.equal(
           '/examples/microfrontends/multipurpose.html?sap-theme=lightLUIGI'
@@ -278,7 +278,7 @@ describe('JS-TEST-APP 2', () => {
         .eq(2)
         .click();
 
-      cy.get('.iframeUserSettingsCtn iframe').then(ifr => {
+      cy.get('.iframeUserSettingsCtn iframe').should(ifr => {
         expect(ifr[0].src).to.equal('http://localhost:4500/examples/microfrontends/customUserSettingsMf.html');
       });
     });

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
@@ -7,8 +7,10 @@ describe('JS-TEST-APP 2', () => {
       openMode: 4
     }
   };
+
   describe('Theming', () => {
     let newConfig;
+
     beforeEach(() => {
       newConfig = structuredClone(defaultLuigiConfig);
       newConfig.settings.theming = {
@@ -17,15 +19,6 @@ describe('JS-TEST-APP 2', () => {
           { id: 'dark', name: 'Fiori3 Dark' }
         ],
         defaultTheme: 'light'
-        // nodeViewURLDecorator: {
-        //   queryStringParameter: {
-        //     keyName: 'sap-theme'
-        //     // optional
-        //     // value: themeId => {
-        //     //   return themeId + 'YES';
-        //     // }
-        //   }
-        // }
       };
       newConfig.navigation.nodes.push({
         pathSegment: 'theming',
@@ -47,6 +40,7 @@ describe('JS-TEST-APP 2', () => {
           .contains('light');
       });
     });
+
     it('Iframe Url should get set with value by default', () => {
       newConfig.settings.theming.nodeViewURLDecorator = {
         queryStringParameter: {
@@ -62,6 +56,7 @@ describe('JS-TEST-APP 2', () => {
         );
       });
     });
+
     it('Iframe Url should get set with custom value', () => {
       newConfig.settings.theming.nodeViewURLDecorator = {
         queryStringParameter: {
@@ -88,10 +83,8 @@ describe('JS-TEST-APP 2', () => {
     beforeEach(() => {
       newConfig = structuredClone(defaultLuigiConfig);
       newConfig.settings.responsiveNavigation = 'semiCollapsible';
-      // cy.window().then(win => {
-      //   win.Luigi.configChanged('settings');
-      // });
     });
+
     it('should check if the btn hide/show left side nav visible', () => {
       cy.visitTestApp('/', newConfig);
       cy.get('[data-testid="semiCollapsibleButton"]').should('be.visible');
@@ -160,8 +153,10 @@ describe('JS-TEST-APP 2', () => {
       cy.get('[data-testid="semiCollapsibleLeftNav"]').should('not.have.class', 'fd-side-nav--condensed');
     });
   });
+
   describe('User settings dialog', () => {
     let newConfig;
+
     beforeEach(() => {
       newConfig = structuredClone(defaultLuigiConfig);
       newConfig.tag = 'user-settings-dialog';
@@ -222,6 +217,7 @@ describe('JS-TEST-APP 2', () => {
         }
       };
     });
+
     it('User settings dialog', () => {
       cy.visitTestApp('/', newConfig);
       cy.get('#app[configversion="user-settings-dialog"]');
@@ -241,15 +237,11 @@ describe('JS-TEST-APP 2', () => {
         .eq(0)
         .click();
       cy.get('[data-testid="lui-us-option0_0"]').click();
-      cy.get('[data-testid="lui-us-input0"]')
-        .should('exist')
-        .should('contain', 'Deutsch');
+      cy.get('[data-testid="lui-us-input0"]').should('contain', 'Deutsch');
 
       cy.get('[data-testid="lui-us-input0"]').click();
       cy.get('[data-testid="lui-us-option0_1"]').click();
-      cy.get('[data-testid="lui-us-input0"]')
-        .should('exist')
-        .should('contain', 'English');
+      cy.get('[data-testid="lui-us-input0"]').should('contain', 'English');
 
       cy.get('[data-testid="lui-us-enum-0"]')
         .eq(0)
@@ -263,6 +255,7 @@ describe('JS-TEST-APP 2', () => {
       cy.get('[data-testid="lui-us-dismissBtn"]').click();
       cy.get('.lui-usersettings-dialog').should('not.exist');
     });
+
     it('Check if external mf is loaded in custom user settings editor', () => {
       cy.visitTestApp('/', newConfig);
       cy.get('#app[configversion="user-settings-dialog"]');
@@ -285,6 +278,7 @@ describe('JS-TEST-APP 2', () => {
 
   describe('Bookmarkable micro frontends', () => {
     let newConfig;
+
     beforeEach(() => {
       newConfig = structuredClone(defaultLuigiConfig);
     });
@@ -302,8 +296,6 @@ describe('JS-TEST-APP 2', () => {
           .withParams({ mp: 'one' })
           .openAsModal('/home/one');
       });
-
-      // cy.wait(150); // it takes some time for the nodeParams be available
 
       // TODO - Accessing LuigiCLient directly results in flaky behavoir, skip for now
       // cy.getModalWindow().then(win => {
@@ -327,7 +319,6 @@ describe('JS-TEST-APP 2', () => {
           .openAsModal('/home/one');
       });
 
-      // cy.wait(150); // it takes some time for the nodeParams be available
       // TODO - Accessing LuigiCLient directly results in flaky behavoir, skip for now
       // cy.getModalWindow().then(win => {
       //   assert.deepEqual(win.LuigiClient.getNodeParams(), { mp: 'one' });
@@ -342,6 +333,7 @@ describe('JS-TEST-APP 2', () => {
 
   describe('GlobalSearchCentered', () => {
     let newConfig;
+
     beforeEach(() => {
       newConfig = structuredClone(defaultLuigiConfig);
       newConfig.globalSearch = {
@@ -356,14 +348,16 @@ describe('JS-TEST-APP 2', () => {
 
       cy.visitTestApp('/home', newConfig);
     });
-    context('Desktop', () => {
+
+    describe('Desktop', () => {
       it('Search on large viewport', () => {
         cy.get('.lui-global-search-btn').should('not.be.visible');
         cy.get('.lui-global-search-cancel-btn').should('not.exist');
         cy.get('.lui-global-search-input').should('be.visible');
       });
     });
-    context('Mobile', () => {
+
+    describe('Mobile', () => {
       it('Search on smaller viewport', () => {
         cy.viewport('iphone-6');
         cy.get('.lui-global-search-btn').should('be.visible');
@@ -387,7 +381,7 @@ describe('JS-TEST-APP 2', () => {
 
   describe('BreadCrumb and NavHeader', () => {
     let newConfig;
-    var breadcrumbsConfig = {
+    const breadcrumbsConfig = {
       clearBeforeRender: true,
       renderer: (el, items, clickHandler) => {
         el.classList.add('myBreadcrumb');
@@ -481,6 +475,7 @@ describe('JS-TEST-APP 2', () => {
         ]
       };
     });
+
     it('Breadcrumb container visible with static nodes', localRetries, () => {
       cy.visitTestApp('/home', newConfig);
       cy.get('#app[configversion="breadcrumbs"]');
@@ -490,6 +485,7 @@ describe('JS-TEST-APP 2', () => {
       cy.get('[data-testid=breadcrumb_Home_index0]').should('be.visible');
       cy.get('[data-testid=breadcrumb_static_index1]').should('be.visible');
     });
+
     it('Breadcrumbs with dynamic nodes', localRetries, () => {
       cy.visitTestApp('/home/dyn/dynValue', newConfig);
       cy.get('#app[configversion="breadcrumbs"]');
@@ -500,6 +496,7 @@ describe('JS-TEST-APP 2', () => {
       cy.get('[data-testid=breadcrumb_dynValue_index2]').should('be.visible');
       cy.get('[data-testid=breadcrumb_1_index3]').should('be.visible');
     });
+
     it('Breadcrumbs with virtual nodes', localRetries, () => {
       cy.visitTestApp('/home/virtual-tree/virtualValue/test', newConfig);
       cy.get('#app[configversion="breadcrumbs"]');
@@ -510,12 +507,14 @@ describe('JS-TEST-APP 2', () => {
       cy.get('[data-testid=breadcrumb_virtualValue_index2]').should('be.visible');
       cy.get('[data-testid=breadcrumb_test_index3]').should('be.visible');
     });
+
     it('dynamic nav header', localRetries, () => {
       cy.visitTestApp('/home/dyn/dynValue', newConfig);
       cy.get('#app[configversion="breadcrumbs"]');
       cy.expectPathToBe('/home/dyn/dynValue/1');
       cy.get('.lui-nav-title .fd-nested-list__title').should('contain', 'dynValue');
     });
+
     it('static nav header', localRetries, () => {
       newConfig.navigation.nodes[0].children[0].children[0].navHeader.label = 'test';
 
@@ -529,6 +528,7 @@ describe('JS-TEST-APP 2', () => {
 
   describe('Encoded ViewURL Search Params with Decorators', () => {
     let newConfig;
+
     beforeEach(() => {
       newConfig = structuredClone(defaultLuigiConfig);
       newConfig.tag = 'encodeViewURL';
@@ -583,8 +583,10 @@ describe('JS-TEST-APP 2', () => {
       );
     });
   });
+
   describe('Transfer theme vars to client', () => {
     let newConfig;
+
     beforeEach(() => {
       newConfig = structuredClone(defaultLuigiConfig);
       newConfig.tag = 'transferThemeVars';
@@ -593,6 +595,7 @@ describe('JS-TEST-APP 2', () => {
         variables: 'fiori'
       };
     });
+
     it('Tranfer var and override it', () => {
       cy.visitTestApp('/home/one', newConfig);
       cy.get('#app[configversion="transferThemeVars"]');

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-theming.cy.js
@@ -102,7 +102,7 @@ describe('JS-TEST-APP 2', () => {
       cy.get('[data-testid="semiCollapsibleButton"]').click();
       cy.get('[data-testid="semiCollapsibleLeftNav"]').should('have.class', 'fd-side-nav--condensed');
 
-      cy.reload().wait(1000);
+      cy.reload();
       cy.window().then(win => {
         win.Luigi.setConfig(newConfig);
       });
@@ -114,7 +114,7 @@ describe('JS-TEST-APP 2', () => {
       cy.window().then(win => {
         win.Luigi.ux().collapseLeftSideNav(false);
       });
-      cy.reload().wait(1000);
+      cy.reload();
       cy.get('[data-testid="semiCollapsibleLeftNav"]').should('not.exist');
     });
   });
@@ -141,7 +141,7 @@ describe('JS-TEST-APP 2', () => {
       cy.get('button.lui-burger').click();
       cy.get('[data-testid="semiCollapsibleLeftNav"]').should('have.class', 'fd-side-nav--condensed');
 
-      cy.reload().wait(1000);
+      cy.reload();
       cy.window().then(win => {
         win.Luigi.setConfig(newConfig);
       });
@@ -153,7 +153,7 @@ describe('JS-TEST-APP 2', () => {
       cy.window().then(win => {
         win.Luigi.ux().collapseLeftSideNav(false);
       });
-      cy.reload().wait(1000);
+      cy.reload();
       cy.window().then(win => {
         win.Luigi.setConfig(newConfig);
       });
@@ -258,7 +258,6 @@ describe('JS-TEST-APP 2', () => {
       cy.get('[data-testid="lui-us-enum-0"]')
         .eq(0)
         .click();
-      cy.wait(500);
       cy.get('[data-testid="lui-us-option0_0"]').should('not.be.visible');
 
       cy.get('[data-testid="lui-us-dismissBtn"]').click();

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/globalSearch.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/globalSearch.cy.js
@@ -9,17 +9,13 @@ describe('Global Search', () => {
       cy.get('input[data-testid="luigi-search-input"]').should('not.be.visible');
 
       // Click on Search Button
-      cy.get('button[data-testid="luigi-search-btn-desktop"]')
-        .should('exist')
-        .click();
+      cy.get('button[data-testid="luigi-search-btn-desktop"]').click();
 
       // Input should be visible
       cy.get('input[data-testid="luigi-search-input"]').should('be.visible');
 
       // Click on Search Button
-      cy.get('button[data-testid="luigi-search-btn-desktop"]')
-        .should('exist')
-        .click();
+      cy.get('button[data-testid="luigi-search-btn-desktop"]').click();
 
       // Input should be not visible
       cy.get('input[data-testid="luigi-search-input"]').should('not.be.visible');
@@ -40,17 +36,13 @@ describe('Global Search', () => {
   describe('Check toggleSearch function ', () => {
     it('toggleSearch had been executed?', () => {
       // Click on Search Button
-      cy.get('button[data-testid="luigi-search-btn-desktop"]')
-        .should('exist')
-        .click();
+      cy.get('button[data-testid="luigi-search-btn-desktop"]').click();
 
       // toggleSearch function should had been executed... input value should be open
       cy.get('input[data-testid="luigi-search-input"]').should('have.attr', 'data-togglesearch', 'open');
 
       // Click on Search Button
-      cy.get('button[data-testid="luigi-search-btn-desktop"]')
-        .should('exist')
-        .click();
+      cy.get('button[data-testid="luigi-search-btn-desktop"]').click();
 
       // toggleSearch function should had been executed...input value should be close
       cy.get('input[data-testid="luigi-search-input"]').should('have.attr', 'data-togglesearch', 'close');
@@ -60,9 +52,7 @@ describe('Global Search', () => {
   describe('Get results', () => {
     it('Type something and get results', () => {
       // Click on Search Button
-      cy.get('button[data-testid="luigi-search-btn-desktop"]')
-        .should('exist')
-        .click();
+      cy.get('button[data-testid="luigi-search-btn-desktop"]').click();
 
       // Type Luigi in search input textbox
       cy.get('input[data-testid="luigi-search-input"]')
@@ -78,9 +68,7 @@ describe('Global Search', () => {
 
     it('Click on Projects result', () => {
       // Click on Search Button
-      cy.get('button[data-testid="luigi-search-btn-desktop"]')
-        .should('exist')
-        .click();
+      cy.get('button[data-testid="luigi-search-btn-desktop"]').click();
 
       // Type Luigi in search input textbox
       cy.get('input[data-testid="luigi-search-input"]')

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/i18n-context-product-app-switcher.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/i18n-context-product-app-switcher.cy.js
@@ -19,7 +19,8 @@ describe('Context switcher', () => {
   it('Add and remove project with context switcher', () => {
     cy.goToProjectsPage();
 
-    cy.get('.fd-app__sidebar').as('sidebar')
+    cy.get('.fd-app__sidebar')
+      .as('sidebar')
       .should('contain', 'Project One')
       .and('contain', 'Project Two')
       .and('not.contain', 'Project 3');
@@ -213,7 +214,8 @@ describe('ProductSwitcher', () => {
         .should('contain', 'hybris');
 
       //check if internal link is there
-      cy.get('.fd-product-switch .fd-product-switch__title').as('title')
+      cy.get('.fd-product-switch .fd-product-switch__title')
+        .as('title')
         .contains('Project One')
         .click();
 

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/i18n-context-product-app-switcher.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/i18n-context-product-app-switcher.cy.js
@@ -19,9 +19,10 @@ describe('Context switcher', () => {
   it('Add and remove project with context switcher', () => {
     cy.goToProjectsPage();
 
-    cy.get('.fd-app__sidebar').should('contain', 'Project One');
-    cy.get('.fd-app__sidebar').should('contain', 'Project Two');
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project 3');
+    cy.get('.fd-app__sidebar').as('sidebar')
+      .should('contain', 'Project One')
+      .and('contain', 'Project Two')
+      .and('not.contain', 'Project 3');
 
     cy.goToOverviewPage();
     cy.expectPathToBe('/overview');
@@ -34,9 +35,10 @@ describe('Context switcher', () => {
 
     cy.expectPathToBe('/projects');
 
-    cy.get('.fd-app__sidebar').should('contain', 'Project One');
-    cy.get('.fd-app__sidebar').should('contain', 'Project Two');
-    cy.get('.fd-app__sidebar').should('contain', 'Project 5');
+    cy.get('@sidebar')
+      .should('contain', 'Project One')
+      .and('contain', 'Project Two')
+      .and('contain', 'Project 5');
 
     cy.get('[data-testid=luigi-alert]').should('have.class', 'fd-message-strip--information');
 
@@ -51,9 +53,10 @@ describe('Context switcher', () => {
 
     cy.expectPathToBe('/projects');
 
-    cy.get('.fd-app__sidebar').should('contain', 'Project One');
-    cy.get('.fd-app__sidebar').should('contain', 'Project Two');
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project 3');
+    cy.get('@sidebar')
+      .should('contain', 'Project One')
+      .and('contain', 'Project Two')
+      .and('not.contain', 'Project 3');
 
     // remove all projects
 
@@ -73,9 +76,10 @@ describe('Context switcher', () => {
 
     cy.expectPathToBe('/projects');
 
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project One');
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project Two');
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project 3');
+    cy.get('@sidebar')
+      .should('not.contain', 'Project One')
+      .and('not.contain', 'Project Two')
+      .and('not.contain', 'Project 3');
 
     cy.get('[data-testid="luigi-contextswitcher-popover"]').should('not.contain', 'Remove Project');
 
@@ -85,9 +89,10 @@ describe('Context switcher', () => {
 
     cy.expectPathToBe('/projects');
 
-    cy.get('.fd-app__sidebar').should('contain', 'Project 1');
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project 2');
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project 3');
+    cy.get('@sidebar')
+      .should('contain', 'Project 1')
+      .and('not.contain', 'Project 2')
+      .and('not.contain', 'Project 3');
 
     cy.get('[data-testid="luigi-contextswitcher-popover"]').should('contain', 'Remove Project');
 
@@ -95,9 +100,10 @@ describe('Context switcher', () => {
 
     cy.expectPathToBe('/projects');
 
-    cy.get('.fd-app__sidebar').should('contain', 'Project 1');
-    cy.get('.fd-app__sidebar').should('contain', 'Project 2');
-    cy.get('.fd-app__sidebar').should('not.contain', 'Project 3');
+    cy.get('@sidebar')
+      .should('contain', 'Project 1')
+      .and('contain', 'Project 2')
+      .and('not.contain', 'Project 3');
 
     cy.get('[data-testid="luigi-contextswitcher-popover"]').should('contain', 'Remove Project');
 
@@ -193,7 +199,8 @@ describe('ProductSwitcher', () => {
   beforeEach(() => {
     cy.visitLoggedIn('/');
   });
-  context('Desktop', () => {
+
+  describe('Desktop', () => {
     beforeEach(() => {
       // run these tests as if in a desktop
       cy.viewport('macbook-15');
@@ -203,16 +210,16 @@ describe('ProductSwitcher', () => {
       //check if hybris is there
       cy.get('.fd-product-switch')
         .click()
-        .contains('hybris');
+        .should('contain', 'hybris');
 
       //check if internal link is there
-      cy.get('.fd-product-switch .fd-product-switch__title')
+      cy.get('.fd-product-switch .fd-product-switch__title').as('title')
         .contains('Project One')
         .click();
 
       cy.expectPathToBe('/projects/pr1');
 
-      cy.get('.fd-product-switch .fd-product-switch__title').should('not.contain', 'Project 3');
+      cy.get('@title').should('not.contain', 'Project 3');
 
       cy.goToOverviewPage();
       cy.expectPathToBe('/overview');
@@ -221,11 +228,11 @@ describe('ProductSwitcher', () => {
       cy.selectContextSwitcherItem('New Project');
       cy.expectPathToBe('/projects');
 
-      cy.get('.fd-product-switch .fd-product-switch__title').should('contain', 'Project 5');
+      cy.get('@title').should('contain', 'Project 5');
 
       cy.get('.fd-product-switch').click();
 
-      cy.get('.fd-product-switch .fd-product-switch__title')
+      cy.get('@title')
         .contains('Project 5')
         .click();
 
@@ -237,7 +244,7 @@ describe('ProductSwitcher', () => {
     });
   });
 
-  context('Mobile', () => {
+  describe('Mobile', () => {
     beforeEach(() => {
       cy.viewport('iphone-6');
     });
@@ -282,6 +289,7 @@ describe('AppSwitcher', () => {
   beforeEach(() => {
     cy.visitLoggedIn('/');
   });
+
   it('Clicking around the app switcher', () => {
     cy.window().then(win => {
       const config = win.Luigi.getConfig();

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/login-flow-nav-dropdown.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/login-flow-nav-dropdown.cy.js
@@ -87,7 +87,8 @@ describe('TopNavDropDown', () => {
   beforeEach(() => {
     cy.visitLoggedIn('/');
   });
-  context('Desktop', () => {
+
+  describe('Desktop', () => {
     beforeEach(() => {
       // run these tests as if in a desktop
       cy.viewport('macbook-15');
@@ -107,7 +108,7 @@ describe('TopNavDropDown', () => {
     });
   });
 
-  context('Mobile', () => {
+  describe('Mobile', () => {
     beforeEach(() => {
       cy.viewport('iphone-6');
     });

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-lifecycle-manager-features.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-lifecycle-manager-features.cy.js
@@ -1,8 +1,4 @@
 describe('Luigi client lifecycle manager features', () => {
-  beforeEach(() => {
-    cy.visitLoggedIn('/');
-  });
-
   it('setAnchor with wc luigi client', () => {
     cy.visitLoggedIn('/projects/pr1/webcomponent');
     cy.expectPathToBe('/projects/pr1/webcomponent');

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-lifecycle-manager-features.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-lifecycle-manager-features.cy.js
@@ -1,11 +1,4 @@
 describe('Luigi client lifecycle manager features', () => {
-  const localRetries = {
-    retries: {
-      runMode: 3,
-      openMode: 3
-    }
-  };
-
   beforeEach(() => {
     cy.visitLoggedIn('/');
   });
@@ -19,13 +12,13 @@ describe('Luigi client lifecycle manager features', () => {
     )
       .shadow()
       .contains('setAnchor')
-      .click()
-      .then(() => {
-        cy.url().should('include', 'LuigiRocks');
-      });
+      .click();
+    cy.url().should('include', 'LuigiRocks');
   });
+
   it('get/add node params with wc luigi client', () => {
     const stub = cy.stub();
+
     cy.on('window:alert', stub);
     cy.visitLoggedIn('/projects/pr1/webcomponent');
     cy.expectPathToBe('/projects/pr1/webcomponent');
@@ -34,10 +27,8 @@ describe('Luigi client lifecycle manager features', () => {
     )
       .shadow()
       .contains('addNodeParams')
-      .click()
-      .then(() => {
-        cy.url().should('include', '?%7ELuigi=rocks');
-      });
+      .click();
+    cy.url().should('include', '?%7ELuigi=rocks');
     cy.get(
       '.wcContainer luigi-wc-687474703a2f2f6c6f63616c686f73743a343230302f6173736574732f68656c6c6f576f726c6457432e6a733f656e'
     )
@@ -51,6 +42,7 @@ describe('Luigi client lifecycle manager features', () => {
 
   it('getCoreSearchParams', () => {
     const stub = cy.stub();
+
     cy.on('window:alert', stub);
     cy.visitLoggedIn('/projects/pr1/webcomponent2?testParam=searchParam1');
     cy.expectPathToBe('/projects/pr1/webcomponent2');
@@ -68,6 +60,7 @@ describe('Luigi client lifecycle manager features', () => {
 
   it('getClientPermissions', () => {
     const stub = cy.stub();
+
     cy.on('window:alert', stub);
     cy.visitLoggedIn('/projects/pr1/webcomponent2');
     cy.expectPathToBe('/projects/pr1/webcomponent2');

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-lifecycle-manager-features.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-lifecycle-manager-features.cy.js
@@ -17,7 +17,7 @@ describe('Luigi client lifecycle manager features', () => {
   });
 
   it('get/add node params with wc luigi client', () => {
-    const stub = cy.stub();
+    const stub = cy.stub().as('alertStub');
 
     cy.on('window:alert', stub);
     cy.visitLoggedIn('/projects/pr1/webcomponent');
@@ -34,14 +34,12 @@ describe('Luigi client lifecycle manager features', () => {
     )
       .shadow()
       .contains('getNodeParams')
-      .click()
-      .then(() => {
-        expect(stub.getCall(0)).to.be.calledWith('{"Luigi":"rocks"}');
-      });
+      .click();
+    cy.get('@alertStub').should('be.calledOnceWith', '{"Luigi":"rocks"}');
   });
 
   it('getCoreSearchParams', () => {
-    const stub = cy.stub();
+    const stub = cy.stub().as('alertStub');
 
     cy.on('window:alert', stub);
     cy.visitLoggedIn('/projects/pr1/webcomponent2?testParam=searchParam1');
@@ -52,14 +50,12 @@ describe('Luigi client lifecycle manager features', () => {
     )
       .shadow()
       .contains('getCoreSearchParams')
-      .click()
-      .then(() => {
-        expect(stub.getCall(0)).to.be.calledWith('{"testParam":"searchParam1"}');
-      });
+      .click();
+    cy.get('@alertStub').should('be.calledOnceWith', '{"testParam":"searchParam1"}');
   });
 
   it('getClientPermissions', () => {
-    const stub = cy.stub();
+    const stub = cy.stub().as('alertStub');
 
     cy.on('window:alert', stub);
     cy.visitLoggedIn('/projects/pr1/webcomponent2');
@@ -70,11 +66,10 @@ describe('Luigi client lifecycle manager features', () => {
     )
       .shadow()
       .contains('getClientPermissions')
-      .click()
-      .then(() => {
-        expect(stub.getCall(0)).to.be.calledWith(
-          '{"changeCurrentLocale":true,"urlParameters":{"testParam":{"read":true}}}'
-        );
-      });
+      .click();
+    cy.get('@alertStub').should(
+      'be.calledOnceWith',
+      '{"changeCurrentLocale":true,"urlParameters":{"testParam":{"read":true}}}'
+    );
   });
 });

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-link-manager-features-4.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-link-manager-features-4.cy.js
@@ -429,11 +429,11 @@ describe('Luigi Client linkManager Webcomponent, Drawer', () => {
 
       cy.get(drawerSelector).should('not.exist');
 
-      cy.get(mfIframeSelector).then($element => {
+      cy.get(mfIframeSelector).should($element => {
         expectToNotBeResized($element);
       });
 
-      cy.get(tabNavSelector).then($element => {
+      cy.get(tabNavSelector).should($element => {
         expectToNotBeResized($element);
       });
     });
@@ -445,11 +445,11 @@ describe('Luigi Client linkManager Webcomponent, Drawer', () => {
 
       cy.get(drawerSelector).should('exist');
 
-      cy.get(mfIframeSelector).then($element => {
+      cy.get(mfIframeSelector).should($element => {
         expectToBeResized($element);
       });
 
-      cy.get(tabNavSelector).then($element => {
+      cy.get(tabNavSelector).should($element => {
         expectToBeResized($element);
       });
     });
@@ -465,7 +465,7 @@ describe('Luigi Client linkManager Webcomponent, Drawer', () => {
 
       cy.get(drawerSelector).should('exist');
 
-      cy.get(splitViewSelector).then($element => {
+      cy.get(splitViewSelector).should($element => {
         expectToBeResized($element);
       });
     });
@@ -481,7 +481,7 @@ describe('Luigi Client linkManager Webcomponent, Drawer', () => {
 
       cy.get(drawerSelector).should('exist');
 
-      cy.get(splitViewSelector).then($element => {
+      cy.get(splitViewSelector).should($element => {
         expectToBeResized($element);
       });
     });
@@ -495,7 +495,7 @@ describe('Luigi Client linkManager Webcomponent, Drawer', () => {
 
       cy.get(drawerSelector).should('exist');
 
-      cy.get(mfIframeSelector).then($element => {
+      cy.get(mfIframeSelector).should($element => {
         mfIframeWidthAfterFirstResize = expectToBeResized($element);
       });
 
@@ -503,7 +503,7 @@ describe('Luigi Client linkManager Webcomponent, Drawer', () => {
         .contains(openDrawerButtonText)
         .click();
 
-      cy.get(mfIframeSelector).then($element => {
+      cy.get(mfIframeSelector).should($element => {
         expect(mfIframeWidthAfterFirstResize).to.equal(expectToBeResized($element));
       });
     });

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-ux-alerts-i18n.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-ux-alerts-i18n.cy.js
@@ -40,6 +40,7 @@ describe('Luigi Client UX Alerts + Localization', () => {
 
       cy.get('[data-testid=luigi-alert]').should('have.class', 'fd-message-strip--information');
     });
+
     it('hides Alert after specified time', () => {
       const closeAfter = 500;
       cy.goToUxManagerMethods($iframeBody);
@@ -54,6 +55,7 @@ describe('Luigi Client UX Alerts + Localization', () => {
         .find('[data-testid=show-luigi-alert]')
         .click();
 
+      // Waiting is part of the test in this case, use of cy.wait() is intended.
       cy.wait(closeAfter - 100); //the time may not be one-millisecond perfect so give it some 'flexibility'
       cy.get('[data-testid=luigi-alert]').should('exist');
 

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-ux-manager-features.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/luigi-client-ux-manager-features.cy.js
@@ -12,7 +12,6 @@ describe('Luigi Client ux manager features', () => {
 
   describe('uxManager', () => {
     it('backdrop', () => {
-      cy.wait(500);
       cy.goToUxManagerMethods($iframeBody);
       cy.wrap($iframeBody).should('not.contain', 'Lorem tipsum dolor sit amet');
       cy.get('.lui-backdrop').should('not.exist');
@@ -122,10 +121,8 @@ describe('Luigi Client ux manager features', () => {
           .click();
 
         cy.get('[data-testid=luigi-loading-spinner]').should('exist');
-
-        cy.wait(250); // give it some time to hide
-
-        cy.get('[data-testid=luigi-loading-spinner]').should('not.exist');
+        // should disappear after a while
+        cy.get('[data-testid=luigi-loading-spinner]', { timeout: 5000 }).should('not.exist');
 
         // show loading indicator
         cy.getIframeBody().then($iframeBody => {
@@ -134,9 +131,8 @@ describe('Luigi Client ux manager features', () => {
             .click();
 
           cy.get('[data-testid=luigi-loading-spinner]').should('exist');
-          cy.wait(250); // give it some time to hide
-          // wait for programmatic hide of loading indicator
-          cy.get('[data-testid=luigi-loading-spinner]').should('not.exist');
+          // should disappear after a while
+          cy.get('[data-testid=luigi-loading-spinner]', { timeout: 5000 }).should('not.exist');
         });
       }
     );

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/microfrontends.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/microfrontends.cy.js
@@ -161,7 +161,6 @@ describe('SplitView Microfrontend', () => {
         }
       ];
       tests.forEach(test => {
-        cy.wait(50);
         test.buttonsVisible.forEach((enabled, index) => {
           cy.splitViewButtons($iframeBody)
             .contains(buttons[index])
@@ -242,22 +241,20 @@ describe('Context Update Listener test', () => {
   });
 
   it('Context in content Area', () => {
-    cy.window().then(win => {
-      cy.wait(2500);
+    // This wait is required to let the Angular component render
+    cy.wait(2500);
 
       cy.getIframeBody().then($iframeBody => {
         cy.wrap($iframeBody)
           .find('#console')
           .should('have.text', 'InitListener called');
 
-        win.Luigi.configChanged();
-        cy.wait(500);
+        cy.window().its('Luigi').invoke('configChanged');
 
         cy.wrap($iframeBody)
           .find('#console')
           .should('have.text', 'ContextUpdateListener called');
       });
-    });
   });
 });
 
@@ -269,8 +266,6 @@ describe('Context Update Listener test', () => {
   });
 
   it('Context in modal', () => {
-    cy.wait(2500);
-
     cy.get('[data-testid=modal-mf] iframe')
       .eq(0)
       .iframe()
@@ -281,7 +276,6 @@ describe('Context Update Listener test', () => {
 
         cy.window().then(win => {
           win.Luigi.configChanged();
-          cy.wait(500);
 
           cy.wrap($iframeBody)
             .find('#console')

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/microfrontends.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/microfrontends.cy.js
@@ -244,17 +244,19 @@ describe('Context Update Listener test', () => {
     // This wait is required to let the Angular component render
     cy.wait(2500);
 
-      cy.getIframeBody().then($iframeBody => {
-        cy.wrap($iframeBody)
-          .find('#console')
-          .should('have.text', 'InitListener called');
+    cy.getIframeBody().then($iframeBody => {
+      cy.wrap($iframeBody)
+        .find('#console')
+        .should('have.text', 'InitListener called');
 
-        cy.window().its('Luigi').invoke('configChanged');
+      cy.window()
+        .its('Luigi')
+        .invoke('configChanged');
 
-        cy.wrap($iframeBody)
-          .find('#console')
-          .should('have.text', 'ContextUpdateListener called');
-      });
+      cy.wrap($iframeBody)
+        .find('#console')
+        .should('have.text', 'ContextUpdateListener called');
+    });
   });
 });
 

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-2.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-2.cy.js
@@ -223,7 +223,7 @@ describe('Navigation', () => {
       cy.expectPathToBe('/projects/pr2/nav-sync/one');
 
       const labels = ['two', 'three', 'four', 'one'];
-      labels.forEach((label) => {
+      labels.forEach(label => {
         cy.getIframeBody().then($iframeBody => {
           cy.wrap($iframeBody)
             .contains(label)

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-2.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-2.cy.js
@@ -18,7 +18,6 @@ describe('Navigation', () => {
           .contains('Overview')
           .click();
 
-        cy.wait(500);
         // dig into the iframe
 
         cy.getIframeBody().then($iframeBody => {
@@ -26,7 +25,6 @@ describe('Navigation', () => {
             .find('.fd-list__item')
             .contains('keepSelectedForChildren')
             .click();
-          cy.wait(500);
         });
 
         cy.expectPathToBe('/projects/pr1/avengers');
@@ -38,7 +36,6 @@ describe('Navigation', () => {
             .find('.fd-list__item')
             .contains('Thor')
             .click();
-          cy.wait(500);
         });
         cy.expectPathToBe('/projects/pr1/avengers/thor');
 
@@ -52,7 +49,6 @@ describe('Navigation', () => {
           .contains('Overview')
           .click();
 
-        cy.wait(500);
         cy.getIframeBody().then($iframeBody => {
           cy.wrap($iframeBody)
             .find('.fd-list__item strong')
@@ -227,10 +223,9 @@ describe('Navigation', () => {
       cy.expectPathToBe('/projects/pr2/nav-sync/one');
 
       const labels = ['two', 'three', 'four', 'one'];
-      labels.forEach((label, index) => {
+      labels.forEach((label) => {
         cy.getIframeBody().then($iframeBody => {
           cy.wrap($iframeBody)
-            // .find('.fd-link')
             .contains(label)
             .click();
         });

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-3.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-3.cy.js
@@ -234,7 +234,6 @@ describe('Navigation', () => {
             .contains('Miscellaneous 2')
             .should('not.exist');
           cy.get('[data-testid="semiCollapsibleButton"]').click();
-          cy.wait(1000);
           cy.get('.fd-tabs__item')
             .contains('Miscellaneous2')
             .should('be.visible');

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-4.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-4.cy.js
@@ -240,7 +240,6 @@ describe('Navigation', () => {
           config.settings.profileType = 'Fiori3';
           config.settings.experimental = { profileMenuFiori3: true };
           win.Luigi.configChanged();
-          cy.wait(1000);
 
           cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
           cy.get('.lui-user-menu-fiori').should('be.visible');
@@ -255,9 +254,6 @@ describe('Navigation', () => {
           config.settings.experimental = { profileMenuFiori3: true };
           win.Luigi.configChanged();
 
-          cy.wait(1000);
-
-          cy.get('[data-testid="luigi-topnav-profile-btn"]').should('exist');
           cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
           cy.get('[data-testid="luigi-topnav-profile-avatar"]').should('exist');
           cy.get('[data-testid="luigi-topnav-profile-initials"]').should('not.exist');

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-4.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-4.cy.js
@@ -3,7 +3,7 @@ describe('Navigation', () => {
     beforeEach(() => {
       cy.visitLoggedIn('/');
     });
-  
+
     it('It should have multiple categories collapsed', () => {
       cy.visit('/projects/pr2/collapsibles');
 
@@ -111,14 +111,10 @@ describe('Navigation', () => {
         // Click link is still here (we haven't changed page)
         cy.wrap(result).find('a[data-testid="navigate-withoutSync-virtual-tree"]');
         // checking if we have highlighted  menu item
-        cy.get('a[href="/projects/pr2/virtual-tree"]')
-          .should('exist')
-          .should('have.class', 'is-selected');
+        cy.get('a[href="/projects/pr2/virtual-tree"]').should('have.class', 'is-selected');
 
         // checking if we have NOT highlighted  menu item
-        cy.get('a[href="/projects/pr2/settings"]')
-          .should('exist')
-          .not('.is-selected');
+        cy.get('a[href="/projects/pr2/settings"]').not('.is-selected');
 
         // CLICK ON navigate-withoutSync-virtual-tree
         // linkManager().withoutSync().navigate('/projects/pr2/virtual-tree')
@@ -131,9 +127,7 @@ describe('Navigation', () => {
         // Click link is still here (we haven't changed page)
         cy.wrap(result).find('a[data-testid="navigate-withoutSync-virtual-tree"]');
         // checking if we have highlighted  menu item
-        cy.get('a[href="/projects/pr2/settings"]')
-          .should('exist')
-          .should('have.class', 'is-selected');
+        cy.get('a[href="/projects/pr2/settings"]').should('have.class', 'is-selected');
       });
     });
 
@@ -162,9 +156,7 @@ describe('Navigation', () => {
           .contains(' with params: project to global settings and back')
           .should('not.exist');
         // checking if we have highlighted  menu item
-        cy.get('a[href="/projects/pr2/virtual-tree"]')
-          .should('exist')
-          .should('have.class', 'is-selected');
+        cy.get('a[href="/projects/pr2/virtual-tree"]').should('have.class', 'is-selected');
 
         cy.wrap(result).contains('Add Segments To The Url content');
       });
@@ -215,7 +207,7 @@ describe('Navigation', () => {
     beforeEach(() => {
       cy.visitLoggedIn('/');
     });
-  
+
     context('Desktop', () => {
       it('not render Fiori3 profile in Shellbar when profileType is equal "simple"', () => {
         cy.window().then(win => {
@@ -223,9 +215,7 @@ describe('Navigation', () => {
           config.settings.profileType = 'simple';
           win.Luigi.configChanged();
 
-          cy.get('[data-testid="luigi-topnav-profile-btn"]')
-            .should('exist')
-            .click();
+          cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
           cy.get('.lui-user-menu-fiori').should('not.exist');
           cy.get('.lui-profile-simple-menu').should('be.visible');
         });
@@ -238,9 +228,7 @@ describe('Navigation', () => {
           config.settings.experimental = { profileMenuFiori3: false };
           win.Luigi.configChanged();
 
-          cy.get('[data-testid="luigi-topnav-profile-btn"]')
-            .should('exist')
-            .click();
+          cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
           cy.get('.lui-user-menu-fiori').should('not.exist');
           cy.get('.lui-profile-simple-menu').should('be.visible');
         });
@@ -254,7 +242,6 @@ describe('Navigation', () => {
           win.Luigi.configChanged();
           cy.wait(1000);
 
-          cy.get('[data-testid="luigi-topnav-profile-btn"]').should('exist');
           cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
           cy.get('.lui-user-menu-fiori').should('be.visible');
           cy.get('.lui-profile-simple-menu').should('not.exist');

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-4.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/navigation-4.cy.js
@@ -1,9 +1,9 @@
 describe('Navigation', () => {
-  beforeEach(() => {
-    cy.visitLoggedIn('/');
-  });
-
   describe('Collapsible Categories / Accordion', () => {
+    beforeEach(() => {
+      cy.visitLoggedIn('/');
+    });
+  
     it('It should have multiple categories collapsed', () => {
       cy.visit('/projects/pr2/collapsibles');
 
@@ -173,6 +173,7 @@ describe('Navigation', () => {
 
   describe('Link withOptions', () => {
     beforeEach(() => {
+      cy.visitLoggedIn('/');
       cy.visitLoggedIn('/projects/pr2');
     });
 
@@ -211,6 +212,10 @@ describe('Navigation', () => {
   });
 
   describe('ProfileMenu Fiori 3 Style', () => {
+    beforeEach(() => {
+      cy.visitLoggedIn('/');
+    });
+  
     context('Desktop', () => {
       it('not render Fiori3 profile in Shellbar when profileType is equal "simple"', () => {
         cy.window().then(win => {

--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/user_settings_dialog.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/user_settings_dialog.cy.js
@@ -3,14 +3,10 @@ describe('Navigation', () => {
 
   const openSettingsDialogBox = () => {
     //Click on User Icon (top menu right)
-    cy.get('[data-testid="luigi-topnav-profile-btn"]')
-      .should('exist')
-      .click();
+    cy.get('[data-testid="luigi-topnav-profile-btn"]').click();
 
     //Click on Setting link and open Dialog Box
-    cy.get('[data-testid="settings-link"]')
-      .should('exist')
-      .click();
+    cy.get('[data-testid="settings-link"]').click();
 
     //Check Dialog is open
     cy.get('.lui-usersettings-dialog').should('exist');
@@ -23,9 +19,7 @@ describe('Navigation', () => {
 
   const saveSettings = () => {
     //Check save button and click
-    cy.get('.lui-usersettings-dialog [data-testid="lui-us-saveBtn"]')
-      .should('exist')
-      .click();
+    cy.get('.lui-usersettings-dialog [data-testid="lui-us-saveBtn"]').click();
 
     //Check settings dialog box is closed...
     cy.get('.lui-usersettings-dialog').should('not.exist');
@@ -33,9 +27,7 @@ describe('Navigation', () => {
 
   const closeSettings = () => {
     //Check cancel button and click
-    cy.get('.lui-usersettings-dialog [data-testid="lui-us-dismissBtn"]')
-      .should('exist')
-      .click();
+    cy.get('.lui-usersettings-dialog [data-testid="lui-us-dismissBtn"]').click();
 
     //Check settings dialog box is closed...
     cy.get('.lui-usersettings-dialog').should('not.exist');
@@ -62,9 +54,6 @@ describe('Navigation', () => {
       cy.get('[data-testid="us-navigation-item"]')
         .eq(0)
         .should('have.class', 'is-selected');
-
-      //Check Name Input exist
-      cy.get('[data-testid="lui-us-input0"]').should('exist');
 
       //Check Name Input has placeholder
       cy.get('[data-testid="lui-us-input0"]')
@@ -103,9 +92,6 @@ describe('Navigation', () => {
         .eq(2)
         .should('have.class', 'is-selected');
 
-      //Check Private Policy Input exist
-      cy.get('[data-testid="lui-us-input0"]').should('exist');
-
       //Check Private Policy Input has placeholder
       cy.get('[data-testid="lui-us-input0"]')
         .invoke('attr', 'placeholder')
@@ -127,19 +113,14 @@ describe('Navigation', () => {
         .should('have.class', 'is-selected');
 
       //Check Name Input field and type a new name
-      cy.get('[data-testid="lui-us-input0"]')
-        .should('exist')
-        .type(setting_name);
+      cy.get('[data-testid="lui-us-input0"]').type(setting_name);
 
       //Email Input field should be disabled and a usual text
       cy.get('[data-testid="lui-us-input1"]')
-        .should('exist')
         .should('have.class', 'fd-text')
         .should('have.attr', 'disabled');
 
-      cy.get('[data-testid="lui-us-label-switch_checkbox"]')
-        .should('exist')
-        .click();
+      cy.get('[data-testid="lui-us-label-switch_checkbox"]').click();
 
       //Check Checkbox is checked
       cy.get('[data-testid="lui-us-checkbox-switch_checkbox"]').should('be.checked');
@@ -188,14 +169,10 @@ describe('Navigation', () => {
         .should('have.length', 4);
 
       //Click on Français list item
-      cy.get('[data-testid="lui-us-option0_2"]')
-        .should('exist')
-        .click();
+      cy.get('[data-testid="lui-us-option0_2"]').click();
 
       //Check Placeholder of input field is Français
-      cy.get('[data-testid="lui-us-input0"]')
-        .should('exist')
-        .should('contain', 'Français');
+      cy.get('[data-testid="lui-us-input0"]').should('contain', 'Français');
 
       //Open button to show enumeration list options
       cy.get('.lui-usersettings-content .fd-page__content .fd-form-item')
@@ -205,30 +182,22 @@ describe('Navigation', () => {
 
       //Choose option one above French
       cy.get('[data-testid="lui-us-enum-0"]')
-        .should('exist')
         .type('{upArrow}')
         .type('{enter}');
 
       //Check Placeholder of input field is English (en)
-      cy.get('[data-testid="lui-us-input0"]')
-        .should('exist')
-        .should('contain', 'English (en)');
+      cy.get('[data-testid="lui-us-input0"]').should('contain', 'English (en)');
 
       //Choose option one below English
       cy.get('[data-testid="lui-us-enum-0"]')
-        .should('exist')
         .type('{downArrow}')
         .type('{enter}');
 
       //Confirm with keyboard: Enter
-      cy.get('.fd-popover__body--dropdown-fill')
-        .should('exist')
-        .type('{enter}');
+      cy.get('.fd-popover__body--dropdown-fill').type('{enter}');
 
       //Check Date Formant Input field and type a new format
-      cy.get('[data-testid="lui-us-input1"]')
-        .should('exist')
-        .type(setting_date_format);
+      cy.get('[data-testid="lui-us-input1"]').type(setting_date_format);
 
       //Save Settings
       saveSettings();
@@ -242,9 +211,7 @@ describe('Navigation', () => {
         .click();
 
       //Check Placeholder of input field is Français
-      cy.get('[data-testid="lui-us-input0"]')
-        .should('exist')
-        .should('contain', 'Français');
+      cy.get('[data-testid="lui-us-input0"]').should('contain', 'Français');
 
       //Check Name Input field and type a new name
       cy.get('[data-testid="lui-us-input1"]').should('have.value', setting_date_format);
@@ -258,9 +225,6 @@ describe('Navigation', () => {
       cy.get('[data-testid="us-navigation-item"]')
         .eq(2)
         .click();
-
-      // //Check Private Policy Input field exist and placeholder is
-      cy.get('[data-testid="lui-us-input0"]').should('exist');
 
       //Check Private Policy Input field exist and placeholder is
       cy.get('[data-testid="lui-us-input0"]').type(setting_privacy_policy);


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Review of remaining test files, after PR #3603.

- Remove/ replace `wait` calls where possible.
- Replace `.then` with `.should` where applicable.
- Simplify some assertions.
- Exchange `cloneDeep` of lodash with standard `structuredClone`.
- Remove unused variables and commented-out code.

**Related issue(s)**
Fixes #3513 
