### PR TITLE
fix return type of compound container init

### DIFF
--- a/container/typings/LuigiCompoundContainer.svelte.d.ts
+++ b/container/typings/LuigiCompoundContainer.svelte.d.ts
@@ -85,5 +85,5 @@ export default class LuigiCompoundContainer extends HTMLElement {
    * Manually triggers the micro frontend rendering process when using defer-init attribute
    * @since 1.0.0
    */
-  init();
+  init(): void;
 }


### PR DESCRIPTION
if not specified, it leads to ts compiler error when "noImplicitAny" is true in consumer apps.