### PR TITLE
Fix loading indicator not going away when fast clicking multiple times to a nav node 

### DIFF
--- a/core/src/App.svelte
+++ b/core/src/App.svelte
@@ -362,6 +362,7 @@
               splitViewWC = obj.splitViewWC;
             } else if (prop === 'showLoadingIndicator') {
               if (obj.showLoadingIndicator === true) {
+                clearTimeout(loadingIndicatorTimeout);
                 loadingIndicatorTimeout = setTimeout(() => {
                   showLoadingIndicator = true;
                 }, 250);


### PR DESCRIPTION
clear timeout before setting it