### PR TITLE
Add pre commit hook for Container Docu generation

### DIFF
--- a/scripts/hooks/generate-docu.sh
+++ b/scripts/hooks/generate-docu.sh
@@ -6,7 +6,7 @@
 # ./scripts/hooks/generate-docu.sh
 
 function check_and_generate_docu() {
-  staged_changes=$(git diff --cached --name-only --diff-filter=ACM | grep -e "core/src/core-api" -e "client/src" -e "container/src"| wc -l)
+  staged_changes=$(git diff --cached --name-only --diff-filter=ACM | grep -e "core/src/core-api" -e "client/src" -e "container"| wc -l)
   if [[ "$staged_changes" != *"0"* ]]; then
     echo "Changes in .js found. Building docu"
     cd scripts

--- a/scripts/hooks/generate-docu.sh
+++ b/scripts/hooks/generate-docu.sh
@@ -6,7 +6,7 @@
 # ./scripts/hooks/generate-docu.sh
 
 function check_and_generate_docu() {
-  staged_changes=$(git diff --cached --name-only --diff-filter=ACM | grep -e "core/src/core-api" -e "client/src" | wc -l)
+  staged_changes=$(git diff --cached --name-only --diff-filter=ACM | grep -e "core/src/core-api" -e "client/src" -e "container/src"| wc -l)
   if [[ "$staged_changes" != *"0"* ]]; then
     echo "Changes in .js found. Building docu"
     cd scripts

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "docu": "npm run docu:container && npm run docu:client && npm run docu:core",
-    "docu:generate:section": "npm run docu:client:generate:section && npm run docu:core:generate:section",
+    "docu:generate:section": "npm run docu:client:generate:section && npm run docu:core:generate:sections",
     "docu:container": "npm run docu:container:validate && npm run docu:container:generate:sections",
     "docu:container:validate": "documentation lint ../container/typings/LuigiContainer.svelte.d.ts ../container/typings/LuigiCompoundContainer.svelte.d.ts",
     "docu:container:generate:sections": "npm run docu:container:generate:container-api && npm run docu:container:generate:compound-container-api",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

To test if generate-docu.sh works properly for container, I added a test variable to ./container/src/LuigiContainer.svelte and a description to ./container/typings/LuigiContainer.svelte.d.ts. When running the husky commit hook (and generate-docu.sh) the variable and the description were automatically written to ./docs/luigi-container-api.md.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Resolves  #3678 
