### PR TITLE
Add the container examples link to docu website side navigation

### DIFF
--- a/docs/navigation-configuration.md
+++ b/docs/navigation-configuration.md
@@ -155,10 +155,10 @@ To define all subsequent nodes, use the category label:
 {
   category: 'Links',
   externalLink: {
-    url: 'http://www.luigi-project.io',
+    url: 'http://www.luigi-project.io/docs/navigation-configuration',
     sameWindow: false
   },
-  label: 'Click here to visit the Luigi homepage',
+  label: 'Click here to visit the Luigi navigation doc',
 },
 ...
 ```
@@ -183,10 +183,10 @@ To define all subsequent nodes, use the category label:
 {
   category: 'anyId',
   externalLink: {
-    url: 'http://www.luigi-project.io',
+    url: 'http://www.luigi-project.io/docs/navigation-configuration',
     sameWindow: false
   },
-  label: 'Click here to visit the Luigi homepage',
+  label: 'Click here to visit the Luigi navigation doc',
 },
 ...
 ```

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -3,15 +3,17 @@ Luigi documentation, deployed via netlify and accessible at https://docs.luigi-p
 
 ## Development
 
-1. Install dependencies. 
+1. Make sure that you are in the `website/docs` folder.
+
+2. Install dependencies. 
 
     `npm install`
 
-2. Build Project.
+3. Build Project.
 
     `npm run build`
 
-3. Run Project: This command will serve Luigi Core on Port 4000 and the Client Microfrontends on Port 4001 on separate servers in parallel. To make sure both servers are running locally run them in separate Terminals
+4. Run Project: This command will serve Luigi Core on Port 4000 and the Client Microfrontends on Port 4001 on separate servers in parallel. To make sure both servers are running locally run them in separate Terminals
 
     `npm run core` and `npm run client`
 

--- a/website/docs/static/public/navigation-nodes.json
+++ b/website/docs/static/public/navigation-nodes.json
@@ -138,5 +138,25 @@
       "categoryPosition": 8,
       "position": 7
     }
+  },
+  {
+    "label": "Luigi Container",
+    "pathSegment": "",
+    "navigationContext": "doc",
+    "keepSelectedForChildren": true,
+    "viewUrl": "__BASE_URL__/docs/",
+    "context": {
+      "doc": ""
+    },
+    "category": {
+      "label": "Examples"
+    },
+    "externalLink": {
+      "url": "https://github.com/SAP/luigi/tree/main/container/examples"
+    },
+    "metaData": {
+      "categoryPosition": 8,
+      "position": 8
+    }
   }
 ]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**

Changes proposed in this pull request:

- Added an external link to the container examples page in the sidebar.
- Added a note to check the path for working on the documentation as GitHub shows README files from nested folders and it's not clear which folder is being referred to.
- Changed some examples to show a different link being added to a category.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #3687 