### PR TITLE
Update navigation-parameters-reference doc with Promise children nodes

### DIFF
--- a/docs/navigation-parameters-reference.md
+++ b/docs/navigation-parameters-reference.md
@@ -293,6 +293,7 @@ Node parameters are all the parameters that can be added to an individual naviga
 ### children
 - **type**: array | function
 - **description**:  in this element, you can specify children nodes. All children nodes will have the same parent prefix URL.
+You can also return a Promise that resolves to an array of nodes. Which can be useful if the child nodes aren't available immediately and need to get fetched asynchronously.
 For example, if you look at our [Fiddle showcase](https://fiddle.luigi-project.io/), you will see that home node has different children: this hierarchy will be reflected in children URLs.
 ```javascript
 navigation: {
@@ -322,6 +323,24 @@ navigation: {
             viewUrl: 'https://sdk.openui5.org/test-resources/sap/m/demokit/cart/webapp/index.html'
         }]
     ...
+    }]
+}
+
+// Example of Children as a Promise
+navigation: {
+  nodes: [{
+    ...,
+    children:  () => {
+      return new Promise((resolve, reject) => {
+        fetch('/node/endpoint').then((...)=>{
+        ...
+          resolve(nodes);
+        });
+      })
+    },
+    ...
+  }]
+}
 ```
 
 ### clientPermissions.changeCurrentLocale


### PR DESCRIPTION
I only updated the Docs, but please still read the description even though this being a ~20 LOC change.

**Description**

Hey it's me again, I just wanted to say it's the same as always I'm new to all of this and if anything is wrong with it please just tell me. If you want or need to contact me, just do so under mail@jotrorox.com.

Best Regards 
Johannes 

Changes proposed in this pull request:
- Updating the description and example for the children parameter on the navigation

**Related issue(s)**
Should resolve #3667 
