### PR TITLE
Makes file size limit consistent

### DIFF
--- a/core/vite.config.mjs
+++ b/core/vite.config.mjs
@@ -44,7 +44,7 @@ export default defineConfig({
   base: '',
   build: {
     sourcemap: true,
-    chunkSizeWarningLimit: 530,
+    chunkSizeWarningLimit: 650,
     rollupOptions: {
       input: ['src/main.js', 'src/styles/fd_horizon.scss', 'src/styles/fd_fiori.scss'],
       output: {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

It appeared we need a consistent file size limit related to 'luigi.js' file - it should be 650 kB just like in 'bundlesize' script

**Related issue(s)**

Resolves #3703
