### PR TITLE
fix flaky compatibility test

### DIFF
--- a/test/e2e-test-application/cypress/e2e/tests/1-angular/login-flow-nav-dropdown.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/1-angular/login-flow-nav-dropdown.cy.js
@@ -78,6 +78,7 @@ describe('Login Flow', () => {
 
     //login again
     cy.contains('Re-Login').click();
+    cy.expectPathToBe('/assets/auth-mock/login-mock.html');
     cy.get('body').should('contain', 'Login to Luigi sample app');
     cy.login('tets@email.com', 'tets');
   });


### PR DESCRIPTION
potential fix under the assumption that the failing is caused by redirect taking too long and therefore the 
cy.get('body') is invoked on the main luigi page before redirect to the login page

<img width="629" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBN1FiQlE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--cfc787e5b4e15a88fdf2650468751a04277cc74f/image.png" alt="image.png" />
