### PR TITLE
Adds optional renderer for navHeader

### DIFF
--- a/core/src/navigation/LeftNav.svelte
+++ b/core/src/navigation/LeftNav.svelte
@@ -160,6 +160,7 @@
     GenericHelpers.requestExperimentalFeature('btpToolLayout', false);
   let btpNavTopCnt;
   let toolLayoutSubCatDelimiter = LuigiConfig.getConfigValue('settings.btpToolLayout.subCategoryDelimiter') || '::';
+  let navHeaderContainer;
 
   const getNodeLabel = node => {
     return NavigationHelpers.getNodeLabel(node);
@@ -248,6 +249,18 @@
     }
   };
 
+  const handleNavHeaderRenderer = () => {
+    const clickHandler = (node) => handleClick(node);
+
+    if (navHeader?.renderer && navHeaderContainer) {
+      if (navHeader.clearBeforeRender) {
+        navHeaderContainer.innerHTML = '';
+      }
+
+      navHeader.renderer(navHeaderContainer, navParentNode, clickHandler);
+    }
+  };
+
   afterUpdate(() => {
     if (!window.Luigi.__btpNavTopCntRszObs) {
       let updateTimeout;
@@ -269,6 +282,7 @@
     } else {
       resetNavEntries();
     }
+    handleNavHeaderRenderer();
   });
 
   beforeUpdate(() => {
@@ -589,7 +603,7 @@
     style="width: var(--luigi__left-sidenav--width); height: 100%;"
   >
     {#if navHeader}
-      <div class="lui-nav-title">
+      <div class="lui-nav-title" bind:this={navHeaderContainer}>
         <ul class="fd-nested-list">
           <li class="fd-nested-list__item">
             <!-- svelte-ignore a11y-missing-attribute -->
@@ -933,7 +947,7 @@
     class="fd-app__sidebar fd-navigation {hideNavComponent ? 'hideNavComponent' : ''} {footerText || semiCollapsibleButton ? 'hasFooter' : ''} {footerText && !semiCollapsibleButton ? 'hasOnlyFooterText' : ''}"
   >
     {#if navHeader}
-      <div class="lui-nav-title">
+      <div class="lui-nav-title" bind:this={navHeaderContainer}>
         <ul class="fd-nested-list">
           <li class="fd-nested-list__item">
             <!-- svelte-ignore a11y-missing-attribute -->

--- a/core/src/navigation/LeftNav.svelte
+++ b/core/src/navigation/LeftNav.svelte
@@ -250,7 +250,7 @@
   };
 
   const handleNavHeaderRenderer = () => {
-    const clickHandler = (node) => handleClick(node);
+    const clickHandler = node => handleClick(node);
 
     if (navHeader?.renderer && navHeaderContainer) {
       if (navHeader.clearBeforeRender) {

--- a/core/src/navigation/LeftNav.svelte
+++ b/core/src/navigation/LeftNav.svelte
@@ -250,7 +250,11 @@
   };
 
   const handleNavHeaderRenderer = () => {
-    const clickHandler = node => handleClick(node);
+    const clickHandler = node => {
+      if (node) {
+        handleClick(node);
+      }
+    };
 
     if (navHeader?.renderer && navHeaderContainer) {
       if (navHeader.clearBeforeRender) {
@@ -604,34 +608,36 @@
   >
     {#if navHeader}
       <div class="lui-nav-title" bind:this={navHeaderContainer}>
-        <ul class="fd-nested-list">
-          <li class="fd-nested-list__item">
-            <!-- svelte-ignore a11y-missing-attribute -->
-            <a class="fd-nested-list__link" title={resolveTooltipText(navHeader, $getTranslation(navHeader.label))}>
-              {#if navHeader.icon}
-                {#if isOpenUIiconName(navHeader.icon)}
-                  <i
-                    class="lui-header-icon fd-nested-list__icon sap-icon {getSapIconStr(navHeader.icon)}"
-                    role="presentation"
-                  />
-                {:else}
-                  <span class="fd-nested-list__icon sap-icon">
-                    <img src={navHeader.icon} alt={navHeader.altText ? navHeader.altText : ''} />
-                  </span>
+        {#if !navHeader.renderer}
+          <ul class="fd-nested-list">
+            <li class="fd-nested-list__item">
+              <!-- svelte-ignore a11y-missing-attribute -->
+              <a class="fd-nested-list__link" title={resolveTooltipText(navHeader, $getTranslation(navHeader.label))}>
+                {#if navHeader.icon}
+                  {#if isOpenUIiconName(navHeader.icon)}
+                    <i
+                      class="lui-header-icon fd-nested-list__icon sap-icon {getSapIconStr(navHeader.icon)}"
+                      role="presentation"
+                    />
+                  {:else}
+                    <span class="fd-nested-list__icon sap-icon">
+                      <img src={navHeader.icon} alt={navHeader.altText ? navHeader.altText : ''} />
+                    </span>
+                  {/if}
                 {/if}
-              {/if}
-              <span class="fd-nested-list__title"> {$getTranslation(navHeader.label)} </span>
-              {#if navHeader.showUpLink}
-                <i
-                  class="lui-nav-up fd-nested-list__icon sap-icon sap-icon--navigation-up-arrow"
-                  role="presentation"
-                  title={$getTranslation('luigi.navigation.up')}
-                  on:click|preventDefault={handleUp}
-                />
-              {/if}
-            </a>
-          </li>
-        </ul>
+                <span class="fd-nested-list__title"> {$getTranslation(navHeader.label)} </span>
+                {#if navHeader.showUpLink}
+                  <i
+                    class="lui-nav-up fd-nested-list__icon sap-icon sap-icon--navigation-up-arrow"
+                    role="presentation"
+                    title={$getTranslation('luigi.navigation.up')}
+                    on:click|preventDefault={handleUp}
+                  />
+                {/if}
+              </a>
+            </li>
+          </ul>
+        {/if}
       </div>
     {/if}
 
@@ -948,34 +954,36 @@
   >
     {#if navHeader}
       <div class="lui-nav-title" bind:this={navHeaderContainer}>
-        <ul class="fd-nested-list">
-          <li class="fd-nested-list__item">
-            <!-- svelte-ignore a11y-missing-attribute -->
-            <a class="fd-nested-list__link" title={resolveTooltipText(navHeader, $getTranslation(navHeader.label))}>
-              {#if navHeader.icon}
-                {#if isOpenUIiconName(navHeader.icon)}
-                  <i
-                    class="lui-header-icon fd-nested-list__icon sap-icon {getSapIconStr(navHeader.icon)}"
-                    role="presentation"
-                  />
-                {:else}
-                  <span class="fd-nested-list__icon sap-icon">
-                    <img src={navHeader.icon} alt={navHeader.altText ? navHeader.altText : ''} />
-                  </span>
+        {#if !navHeader.renderer}
+          <ul class="fd-nested-list">
+            <li class="fd-nested-list__item">
+              <!-- svelte-ignore a11y-missing-attribute -->
+              <a class="fd-nested-list__link" title={resolveTooltipText(navHeader, $getTranslation(navHeader.label))}>
+                {#if navHeader.icon}
+                  {#if isOpenUIiconName(navHeader.icon)}
+                    <i
+                      class="lui-header-icon fd-nested-list__icon sap-icon {getSapIconStr(navHeader.icon)}"
+                      role="presentation"
+                    />
+                  {:else}
+                    <span class="fd-nested-list__icon sap-icon">
+                      <img src={navHeader.icon} alt={navHeader.altText ? navHeader.altText : ''} />
+                    </span>
+                  {/if}
                 {/if}
-              {/if}
-              <span class="fd-nested-list__title"> {$getTranslation(navHeader.label)} </span>
-              {#if navHeader.showUpLink}
-                <i
-                  class="lui-nav-up fd-nested-list__icon sap-icon sap-icon--navigation-up-arrow"
-                  role="presentation"
-                  title={$getTranslation('luigi.navigation.up')}
-                  on:click|preventDefault={handleUp}
-                />
-              {/if}
-            </a>
-          </li>
-        </ul>
+                <span class="fd-nested-list__title"> {$getTranslation(navHeader.label)} </span>
+                {#if navHeader.showUpLink}
+                  <i
+                    class="lui-nav-up fd-nested-list__icon sap-icon sap-icon--navigation-up-arrow"
+                    role="presentation"
+                    title={$getTranslation('luigi.navigation.up')}
+                    on:click|preventDefault={handleUp}
+                  />
+                {/if}
+              </a>
+            </li>
+          </ul>
+        {/if}
       </div>
     {/if}
     <nav


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- adds optional renderer for navHeader

**Related issue(s)**

Resolves #3912

**Sample usage**

```javascript
navHeader: {
  icon: 'sys-help',
  label: 'Header Title',
  clearBeforeRender: false,
  renderer: (containerElement, nodeItem, clickHandler) => {
    if (containerElement) {
      const linkElement = containerElement.querySelector('a');

      linkElement.style.backgroundColor = 'green';
      [...linkElement.children].map(child => (child.style.color = 'white'));
    }
  }
}
```