### PR TITLE
Fix: Wrong backgroundColor for profile initials

### DIFF
--- a/core/src/navigation/TopNav.svelte
+++ b/core/src/navigation/TopNav.svelte
@@ -600,7 +600,7 @@
                   />
                 {:else}
                   <button
-                    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-avatar--thumbnail"
+                    class="fd-avatar fd-avatar--xs fd-avatar--circle fd-shellbar__avatar--circle"
                     aria-expanded="true"
                     aria-haspopup="true"
                     title={userInfo.name ? userInfo.name : undefined}


### PR DESCRIPTION
Currently with the following settings the Initials has no backgroundColor:
![Bildschirmfoto 2025-02-18 um 12 12 28](https://github.com/user-attachments/assets/7eab30b1-8cba-4a2b-9241-eadb71c30a44)


Can be reproduced by the following steps:

1. index.html
  -> replace `<link rel='stylesheet' href='/public/luigi.css'>` with `<link rel='stylesheet' href='/public/luigi_horizon.css'>`
2. Luigi config:
```
settings: {
  ....
   responsiveNavigation: 'Fiori3',
   profileType: 'Fiori3',
   experimental: {
      profileMenuFiori3: true
   }
},
navigation: {
  ...nodes,
  profile: {
          logout: {
            label: 'Sign Out',
            icon: "sys-cancel"
          },
          staticUserInfoFn: () => {
            return new Promise(resolve => {
              resolve({
                name: 'Static User',
                initials: 'LU',
                email: 'other.luigi.user@example.com',
                description: 'Luigi Developer'
              });
            });
          }
        }
}
```