### PR TITLE
Add Ctrl+S/Cmd+S save functionality in App.svelte as written in #4272

### DIFF
--- a/website/fiddle/src/App.svelte
+++ b/website/fiddle/src/App.svelte
@@ -173,7 +173,19 @@
   });
 </script>
 
-<svelte:window on:click={closeDropdowns} on:blur={closeDropdowns} />
+<svelte:window on:click={closeDropdowns} on:blur={closeDropdowns} on:keydown={event => {
+  // Handle save key event (Ctrl+S or Cmd+S)
+  if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+    event.preventDefault();
+    if (document.body.classList.contains('editorVisible')) {
+      if (window.innerWidth < 600) {
+        saveConfigTA();
+      } else {
+        saveConfig();
+      }
+    }
+  }
+}} />
 <div class="editor_container">
   <div class="fd-dialog" role="dialog">
     <div class="fd-dialog__content" role="document" style="width:80%; max-width:80%;">


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
Adding Ctrl+S/Cmd+S save functionality in the App.svelte for instant applying changes in the editor

**Related issue(s)**
#4272 

> Btw. it has been a long time not working with this codebase, I'm sorry if I forgot something or didn't something required, just tell me and I will try to address it as fast as possible.

Also, sorry @walmazacn I only saw you self-assigned it after already doing the commit