### PR TITLE
Update TabNav.svelte

### DIFF
--- a/core/src/navigation/TabNav.svelte
+++ b/core/src/navigation/TabNav.svelte
@@ -141,7 +141,7 @@
    */
   const clearTabNav = () => {
     // Check if tabs container header exists
-    if (tabsContainerHeader !== undefined) {
+    if (tabsContainerHeader) {
       // Get all tab elements
       const tabs = [...tabsContainerHeader.children];
 


### PR DESCRIPTION
clearTabNav can be null as well, which causes error `Cannot read properties of null (reading 'children')`