### PR TITLE
fix: Handle undefined activeFeatureToggleList

### DIFF
--- a/client/src/lifecycleManager.js
+++ b/client/src/lifecycleManager.js
@@ -417,7 +417,7 @@ class LifecycleManager extends LuigiClientBase {
    * const activeFeatureToggleList = LuigiClient.getActiveFeatureToggles()
    */
   getActiveFeatureToggles() {
-    return this.currentContext.internal.activeFeatureToggleList;
+    return this.currentContext.internal.activeFeatureToggleList ?? [];
   }
 
   /**


### PR DESCRIPTION
Return an empty array if activeFeatureToggleList is undefined.

it throws right now
> TypeError: Cannot read properties of undefined (reading 'includes')