### PR TITLE
feat: simplify contextSignal usage

### DIFF
--- a/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts
+++ b/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts
@@ -14,6 +14,11 @@ export class LuigiContextServiceImpl implements LuigiContextService {
   private currentContext!: IContextMessage;
   private ngZone = inject(NgZone);
 
+  /**
+   * Get a signal that emits when context is set.
+   */
+  public contextSignal = this.signalContext.asReadonly();
+
   constructor() {
     addInitListener((initContext: Context) => {
       this.addListener(ILuigiContextTypes.INIT, initContext);
@@ -28,13 +33,6 @@ export class LuigiContextServiceImpl implements LuigiContextService {
       contextType,
       context
     } as IContextMessage);
-  }
-
-  /**
-   * Get a signal that emits when context is set.
-   */
-  public contextSignal(): Signal<IContextMessage | undefined> {
-    return this.signalContext.asReadonly();
   }
 
   /**


### PR DESCRIPTION
before: `service.contextSignal()()`
after: `service.contextSignal()`
