### PR TITLE
Replace template virtual tree path

### DIFF
--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -32,10 +32,7 @@ const createContainer = async (node: Node, luigi: Luigi, luigiParams?: LuigiPara
     lcc.viewurl = node.viewUrl
       ? serviceRegistry
           .get(ViewUrlDecoratorSvc)
-          .applyDecorators(
-            RoutingHelpers.substituteViewUrl(node.viewUrl, pathParams, luigi),
-            node.decodeViewUrl ?? false
-          )
+          .applyDecorators(RoutingHelpers.substituteViewUrl(node, pathParams, luigi), node.decodeViewUrl ?? false)
       : '';
     lcc.webcomponent = node.webcomponent ?? false;
     lcc.compoundConfig = node.compound;
@@ -61,10 +58,7 @@ const createContainer = async (node: Node, luigi: Luigi, luigiParams?: LuigiPara
     lc.viewurl = node.viewUrl
       ? serviceRegistry
           .get(ViewUrlDecoratorSvc)
-          .applyDecorators(
-            RoutingHelpers.substituteViewUrl(node.viewUrl, pathParams, luigi),
-            node.decodeViewUrl ?? false
-          )
+          .applyDecorators(RoutingHelpers.substituteViewUrl(node, pathParams, luigi), node.decodeViewUrl ?? false)
       : '';
     lc.webcomponent = node.webcomponent ?? false;
     (lc as any).context = node.context;
@@ -252,7 +246,7 @@ export const UIModule = {
             ? serviceRegistry
                 .get(ViewUrlDecoratorSvc)
                 .applyDecorators(
-                  RoutingHelpers.substituteViewUrl(currentNode.viewUrl, pathParams, luigi),
+                  RoutingHelpers.substituteViewUrl(currentNode, pathParams, luigi),
                   currentNode.decodeViewUrl ?? false
                 )
             : '';

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -907,7 +907,20 @@ export class NavigationService {
       return str;
     }
     newStr += ':virtualSegment_' + _virtualPathIndex + '/';
-    return str + '/' + newStr;
+    let vViewUrl = str;
+    if (str.includes('{virtualTreePath}')) {
+      vViewUrl = str.replace('{virtualTreePath}', newStr);
+    } else {
+      vViewUrl = str + '/' + newStr;
+    }
+    try {
+      if (new URL(vViewUrl, 'http://dummy-base').origin === new URL(str, 'http://dummy-base').origin) {
+        return vViewUrl;
+      }
+    } catch (err) {
+      console.error('Error building virtual view URL -- make sure virtualTreePath is not part of origin.', err);
+    }
+    return str;
   }
 
   /**

--- a/core-modular/src/utilities/helpers/routing-helpers.ts
+++ b/core-modular/src/utilities/helpers/routing-helpers.ts
@@ -697,13 +697,21 @@ export const RoutingHelpers = {
       : this.buildRoute(node.parent, `/${node.parent.pathSegment}${path}`, params);
   },
 
-  substituteViewUrl(viewUrl: string, pathParams: Record<string, string>, luigi: Luigi): string {
+  substituteViewUrl(node: Node, pathParams: Record<string, string>, luigi: Luigi): string {
+    if (!node.viewUrl) {
+      return '';
+    }
+
+    let viewUrl = node.viewUrl;
     //TODO issue nr 4575
     //currently minimal requirement for this task
     // const contextVarPrefix = 'context.';
     // const nodeParamsVarPrefix = 'nodeParams.';
     // const searchQuery = 'routing.queryParams';
 
+    if (node.virtualTree) {
+      viewUrl = viewUrl.replace('{virtualTreePath}', '');
+    }
     viewUrl = GenericHelpers.replaceVars(viewUrl, pathParams, ':', false);
     // viewUrl = GenericHelpers.replaceVars(viewUrl, pathData.context, contextVarPrefix);
     // viewUrl = GenericHelpers.replaceVars(viewUrl, pathData.nodeParams, nodeParamsVarPrefix);

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -1155,6 +1155,41 @@ describe('NavigationService', () => {
 
       expect(result).toBe('/base/:virtualSegment_1/');
     });
+
+    it('should replace {virtualTreePath} placeholder instead of appending', () => {
+      const result = navigationService.buildVirtualViewUrl(
+        'https://mf.luigi-project.io/app/{virtualTreePath}details',
+        {
+          virtualSegment_1: 'foo',
+          virtualSegment_2: 'bar'
+        },
+        3
+      );
+
+      expect(result).toBe(
+        'https://mf.luigi-project.io/app/:virtualSegment_1/:virtualSegment_2/:virtualSegment_3/details'
+      );
+    });
+
+    it('should replace {virtualTreePath} placeholder with only the new index segment when no prior virtualSegments exist', () => {
+      const result = navigationService.buildVirtualViewUrl('https://mf.luigi-project.io/{virtualTreePath}view', {}, 1);
+
+      expect(result).toBe('https://mf.luigi-project.io/:virtualSegment_1/view');
+    });
+
+    it('should return original string and log error when {virtualTreePath} is part of the origin', () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const str = 'https://{virtualTreePath}.luigi-project.io/app';
+
+      const result = navigationService.buildVirtualViewUrl(str, {}, 1);
+
+      expect(result).toBe(str);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Error building virtual view URL -- make sure virtualTreePath is not part of origin.',
+        expect.any(Error)
+      );
+      errorSpy.mockRestore();
+    });
   });
 
   describe('buildVirtualTree', () => {

--- a/core-modular/test/utilities/helpers/routing-helpers.spec.ts
+++ b/core-modular/test/utilities/helpers/routing-helpers.spec.ts
@@ -637,4 +637,37 @@ describe('Routing-helpers', () => {
       expect(result).toBe('/home/123/details/info');
     });
   });
+
+  describe('substituteViewUrl', () => {
+    it('should remove {virtualTreePath} placeholder when node has virtualTree=true', () => {
+      const node = {
+        pathSegment: 'virtual',
+        virtualTree: true,
+        viewUrl: 'https://mf.luigi-project.io/app/{virtualTreePath}details'
+      };
+
+      const result = RoutingHelpers.substituteViewUrl(node, {}, {} as any);
+
+      expect(result).toBe('https://mf.luigi-project.io/app/details');
+    });
+
+    it('should keep {virtualTreePath} placeholder when node has no virtualTree', () => {
+      const node = {
+        pathSegment: 'static',
+        viewUrl: 'https://mf.luigi-project.io/app/{virtualTreePath}details'
+      };
+
+      const result = RoutingHelpers.substituteViewUrl(node, {}, {} as any);
+
+      expect(result).toContain('{virtualTreePath}');
+    });
+
+    it('should return empty string when node has no viewUrl', () => {
+      const node = { pathSegment: 'empty' };
+
+      const result = RoutingHelpers.substituteViewUrl(node, {}, {} as any);
+
+      expect(result).toBe('');
+    });
+  });
 });

--- a/core/src/navigation/services/navigation.js
+++ b/core/src/navigation/services/navigation.js
@@ -198,7 +198,21 @@ class NavigationClass {
       return str;
     }
     newStr += ':virtualSegment_' + _virtualPathIndex + '/';
-    return str + '/' + newStr;
+
+    let vViewUrl = str;
+    if (str.includes('{virtualTreePath}')) {
+      vViewUrl = str.replace('{virtualTreePath}', newStr);
+    } else {
+      vViewUrl = str + '/' + newStr;
+    }
+    try {
+      if (new URL(vViewUrl, 'http://dummy-base').origin === new URL(str, 'http://dummy-base').origin) {
+        return vViewUrl;
+      }
+    } catch (err) {
+      console.error('Error building virtual view URL -- make sure virtualTreePath is not part of origin.', err);
+    }
+    return str;
   }
 
   buildVirtualTree(node, nodeNamesInCurrentPath, pathParams) {
@@ -232,7 +246,6 @@ class NavigationClass {
         _virtualPathIndex,
         _virtualViewUrl
       });
-
       const isVirtualChildren =
         Array.isArray(node.children) && node.children.length > 0 ? node.children[0]._virtualTree : false;
       if (node.children && !isVirtualChildren) {

--- a/core/src/utilities/helpers/routing-helpers.js
+++ b/core/src/utilities/helpers/routing-helpers.js
@@ -335,6 +335,9 @@ class RoutingHelpersClass {
     const nodeParamsVarPrefix = 'nodeParams.';
     const searchQuery = 'routing.queryParams';
 
+    if (componentData?.currentNode?.virtualTree) {
+      viewUrl = viewUrl.replace('{virtualTreePath}', '');
+    }
     viewUrl = GenericHelpers.replaceVars(viewUrl, componentData.pathParams, ':', false);
     viewUrl = GenericHelpers.replaceVars(viewUrl, componentData.context, contextVarPrefix);
     viewUrl = GenericHelpers.replaceVars(viewUrl, componentData.nodeParams, nodeParamsVarPrefix);

--- a/core/test/services/navigation.spec.js
+++ b/core/test/services/navigation.spec.js
@@ -7,9 +7,9 @@ const expect = chai.expect;
 const assert = chai.assert;
 const sinon = require('sinon');
 
-const sampleNavPromise = new Promise(function(resolve) {
+const sampleNavPromise = new Promise(function (resolve) {
   const lazyLoadedChildrenNodesProviderFn = () => {
-    return new Promise(function(resolve) {
+    return new Promise(function (resolve) {
       resolve([
         {
           pathSegment: 'b1',
@@ -53,13 +53,13 @@ const sampleNavPromise = new Promise(function(resolve) {
   ]);
 });
 
-describe('Navigation', function() {
+describe('Navigation', function () {
   jest.retryTimes(2);
 
   beforeAll(() => {
     function mockStorage() {
       return {
-        getItem: function(key) {
+        getItem: function (key) {
           return JSON.stringify({
             accessTokenExpirationDate: Number(new Date()) + 1
           });
@@ -85,7 +85,7 @@ describe('Navigation', function() {
     sinon.reset();
   });
 
-  describe('getNavigationPath', function() {
+  describe('getNavigationPath', function () {
     it('should not fail for undefined arguments', () => {
       Navigation.getNavigationPath(undefined, undefined);
     });
@@ -933,6 +933,41 @@ describe('Navigation', function() {
       // trailing slash is expected, it gets removed later by trimTrailingSlash() before setting viewUrl
       const expected = 'https://mf.luigi-project.io#!/x/:virtualSegment_1/:virtualSegment_2/:virtualSegment_3/';
 
+      assert.equal(Navigation.buildVirtualViewUrl(mock.url, mock.pathParams, mock.index), expected);
+    });
+    it('replaces {virtualTreePath} placeholder instead of appending', () => {
+      const mock = {
+        url: 'https://mf.luigi-project.io/app/{virtualTreePath}details',
+        pathParams: {
+          virtualSegment_1: 'one',
+          virtualSegment_2: 'two'
+        },
+        index: 3
+      };
+
+      const expected = 'https://mf.luigi-project.io/app/:virtualSegment_1/:virtualSegment_2/:virtualSegment_3/details';
+
+      assert.equal(Navigation.buildVirtualViewUrl(mock.url, mock.pathParams, mock.index), expected);
+    });
+    it('returns original string when origin would change due to {virtualTreePath} in origin', () => {
+      const mock = {
+        url: 'https://{virtualTreePath}.luigi-project.io/app',
+        pathParams: {},
+        index: 1
+      };
+
+      assert.equal(Navigation.buildVirtualViewUrl(mock.url, mock.pathParams, mock.index), mock.url);
+      sinon.assert.calledOnce(console.error);
+    });
+    it('returns original string when {virtualTreePath} replacement changes the origin', () => {
+      const mock = {
+        url: 'https://mf.luigi-project.io/{virtualTreePath}',
+        pathParams: {},
+        index: 1
+      };
+      // The replacement produces 'https://mf.luigi-project.io/:virtualSegment_1/'
+      // which has the same origin, so it should be returned as-is (valid case)
+      const expected = 'https://mf.luigi-project.io/:virtualSegment_1/';
       assert.equal(Navigation.buildVirtualViewUrl(mock.url, mock.pathParams, mock.index), expected);
     });
   });

--- a/core/test/utilities/helpers/routing-helpers.spec.js
+++ b/core/test/utilities/helpers/routing-helpers.spec.js
@@ -104,6 +104,23 @@ describe('Routing-helpers', () => {
       expect(RoutingHelpers.getI18nViewUrl(viewUrl)).to.equal(expected);
     });
 
+    it('substituteViewUrl - removes {virtualTreePath} placeholder when currentNode has virtualTree=true', () => {
+      const viewUrl = 'https://mf.luigi-project.io/app/{virtualTreePath}details';
+      const expected = 'https://mf.luigi-project.io/app/details';
+
+      expect(
+        RoutingHelpers.substituteViewUrl(viewUrl, { currentNode: { virtualTree: true }, pathParams: {} })
+      ).to.equal(expected);
+    });
+
+    it('substituteViewUrl - keeps {virtualTreePath} placeholder when currentNode has no virtualTree', () => {
+      const viewUrl = 'https://mf.luigi-project.io/app/{virtualTreePath}details';
+
+      const result = RoutingHelpers.substituteViewUrl(viewUrl, { currentNode: {}, pathParams: {} });
+
+      expect(result).to.include('{virtualTreePath}');
+    });
+
     it('substituteViewUrl - substitutes {i18n.currentLocale} variable to current locale', () => {
       const viewUrl = '/{i18n.currentLocale}/microfrontend.html';
       const expected = '/en/microfrontend.html';

--- a/docs/navigation-advanced.md
+++ b/docs/navigation-advanced.md
@@ -195,8 +195,8 @@ If you are using [localization](https://docs.luigi-project.io/docs/i18n) and tra
 
  The **{i18n.currentLocale}** parameter will be replaced by the value of `LuigiI18N.getCurrentLocale()`, for example `https://example.com/en/microfrontend.html`
 
- If you are using [virtualTree](https://docs.luigi-project.io/docs/navigation-parameters-reference?section=virtualtree) and your viewUrl contains {virtualTreePath}, Luigi replaces this template with the virtual tree path.
- Note that `{virtualTreePath}` does **not** include a leading slash — you must add it yourself in the configuration.
+ If you are using [virtualTree](https://docs.luigi-project.io/docs/navigation-parameters-reference?section=virtualtree) and your viewUrl contains `{virtualTreePath}`, Luigi replaces this placeholder with the accumulated virtual path segments.
+ Note that `{virtualTreePath}` does **not** include a leading slash — you need the `/` before the placeholder in the URL. The replacement always ends with a trailing `/`, so you can place a path suffix directly after it.
  For example, if the node's **viewUrl** is configured as:
 
 ```javascript
@@ -206,7 +206,7 @@ If you are using [localization](https://docs.luigi-project.io/docs/i18n) and tra
   virtualTree: true
 }
 ```
-Luigi will transform the URL to `https://example.com/home/overview?luigi=super`,
+Luigi will transform the URL to `https://example.com/home/overview/?luigi=super`,
 
 In all these cases, the parameter is automatically replaced by the real value.
 

--- a/docs/navigation-advanced.md
+++ b/docs/navigation-advanced.md
@@ -195,6 +195,19 @@ If you are using [localization](https://docs.luigi-project.io/docs/i18n) and tra
 
  The **{i18n.currentLocale}** parameter will be replaced by the value of `LuigiI18N.getCurrentLocale()`, for example `https://example.com/en/microfrontend.html`
 
+ If you are using [virtualTree](https://docs.luigi-project.io/docs/navigation-parameters-reference?section=virtualtree) and your viewUrl contains {virtualTreePath}, Luigi replaces this template with the virtual tree path.
+ Note that `{virtualTreePath}` does **not** include a leading slash — you must add it yourself in the configuration.
+ For example, if the node's **viewUrl** is configured as:
+
+```javascript
+{
+  pathSegment: ':virtualSegment_1',
+  viewUrl: 'https://example.com/{virtualTreePath}?luigi=super',
+  virtualTree: true
+}
+```
+Luigi will transform the URL to `https://example.com/home/overview?luigi=super`,
+
 In all these cases, the parameter is automatically replaced by the real value.
 
 ### Dynamic Node parameters


### PR DESCRIPTION
Adds a placeholder resolution variable virtualTreePath to the viewUrl processing , which will be replaced by the sub-route, if defined. If not defined, sub-route will be appended as before.