### PR TITLE
Prevent custom message dispatch from triggering internal event l…

### DIFF
--- a/client/src/helpers.js
+++ b/client/src/helpers.js
@@ -15,7 +15,7 @@ class Helpers {
       if (evt.data.msg === 'custom') {
         const message = this.convertCustomMessageInternalToUser(evt.data);
         this.listeners
-          .filter((listener) => listener.name === message.id)
+          .filter((listener) => listener.name === message.id && listener.isCustomMessage)
           .map((listener) => listener.eventFn(message, listener.listenerId));
       } else {
         this.listeners
@@ -52,14 +52,16 @@ class Helpers {
    * @private
    * @param {string} name - event name
    * @param {function} eventFn - callback function
+   * @param {boolean} isCustomMessage - flag indicating if the listener is for custom messages
    * @returns {string} listener id
    */
-  addEventListener(name, eventFn) {
+  addEventListener(name, eventFn, isCustomMessage = false) {
     const listenerId = this.getRandomId();
     this.listeners.push({
       name,
       eventFn,
-      listenerId
+      listenerId,
+      isCustomMessage
     });
     return listenerId;
   }

--- a/client/src/lifecycleManager.js
+++ b/client/src/lifecycleManager.js
@@ -356,9 +356,13 @@ class LifecycleManager extends LuigiClientBase {
    * const customMsgId = LuigiClient.addCustomMessageListener('myapp.project-updated', (data) => doSomething(data))
    */
   addCustomMessageListener(customMessageId, customMessageListener) {
-    return helpers.addEventListener(customMessageId, (customMessage, listenerId) => {
-      return customMessageListener(customMessage, listenerId);
-    });
+    return helpers.addEventListener(
+      customMessageId,
+      (customMessage, listenerId) => {
+        return customMessageListener(customMessage, listenerId);
+      },
+      true
+    );
   }
 
   /**


### PR DESCRIPTION
- Add `isCustomMessage` flag to `addEventListener` to distinguish custom message listeners from internal event listeners
- Filter custom message dispatch to only invoke listeners explicitly registered via `addCustomMessageListener`
- Prevents internal event listeners with coincidentally matching names from being triggered by custom messages