### PR TITLE
docs: add header subtitle setting

### DIFF
--- a/docs/general-settings.md
+++ b/docs/general-settings.md
@@ -33,6 +33,7 @@ settings: {
   header: {  object / function / Promise
     logo: 'path/to/image.png',
     title: 'Luigi Demo',
+    subTitle: 'Application subtitle',
     favicon: 'path/to/favicon.ico'
   },
   featureToggles : {
@@ -202,10 +203,21 @@ Take a look at our [i18n](i18n.md) section for an implementation suggestion.
 ### header.title
 - **type**: string
 - **description**: defines the top left navigation title.
-- **example**: 
+- **example**:
 ```
  header: {  object / function / Promise
     title: 'Luigi Demo'
+  },
+```
+
+### header.subTitle
+- **type**: string
+- **description**: defines the subtitle displayed below the top left navigation title.
+- **example**:
+```
+ header: {  object / function / Promise
+    title: 'Luigi Demo',
+    subTitle: 'Application subtitle'
   },
 ```
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Document `settings.header.subTitle` in the General settings page.
- Add `subTitle` to the existing `settings.header` example.
- Keep the documented casing aligned with the implementation, which uses `header.subTitle`.

**Tests**

- `git diff --check`
- Verified `docs/general-settings.md` contains `### header.subTitle` and the new `subTitle` example.
- Verified `core/src/navigation/services/header.js` uses `header.subTitle`.

**Related issue(s)**

Fixes #5090
