### PR TITLE
add commit-msg hook to check DCO

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
    },
    "husky": {
       "hooks": {
-         "pre-commit": "git diff --quiet HEAD -- container || npm run lint --prefix=container && npm run code-quality ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh &&  ./scripts/hooks/prevent-illegal-characters.sh"
+         "pre-commit": "git diff --quiet HEAD -- container || npm run lint --prefix=container && npm run code-quality ./scripts/hooks/remove-test-prefixes.sh && ./scripts/hooks/generate-docu.sh &&  ./scripts/hooks/prevent-illegal-characters.sh",
+         "commit-msg": "./scripts/hooks/check-signoff.sh $HUSKY_GIT_PARAMS"
       }
    },
    "codeQuality": {

--- a/scripts/hooks/check-signoff.sh
+++ b/scripts/hooks/check-signoff.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+msg=$(cat "$1")
+sob_count=$(echo "$msg" | grep -c "^Signed-off-by: .* <.*>$")
+
+if [ "$sob_count" -eq 0 ]; then
+  echo "ERROR: Commit message must contain a Signed-off-by line."
+  echo "Use 'git commit --signoff' or add manually."
+  exit 1
+fi
+
+if [ "$sob_count" -gt 1 ]; then
+  echo "ERROR: Commit message must contain exactly one Signed-off-by line."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
commit-msg hook, fails if commit message has duplicate or no "Signed-off-by" line.