### PR TITLE
Fix navigation guards and node params comparison in core-modular

### DIFF
--- a/core-modular/src/core-api/navigation.ts
+++ b/core-modular/src/core-api/navigation.ts
@@ -44,6 +44,11 @@ export class Navigation {
     splitViewSettings?: any,
     drawerSettings?: any
   ): Promise<void> => {
+    if (path === '/' && (modalSettings || drawerSettings)) {
+      console.warn('Navigation with an absolute path prevented.');
+      return Promise.reject(new Error('Navigation with an absolute path prevented.'));
+    }
+
     const relativePath = path[0] !== '/';
     this.options.relative = relativePath;
     const navRequestParams: NavigationRequestParams = {
@@ -93,6 +98,11 @@ export class Navigation {
   };
 
   openAsModal = async (path: string, modalSettings: ModalSettings, onCloseCallback?: () => void) => {
+    if (path === '/') {
+      console.warn('Navigation with an absolute path prevented.');
+      return Promise.reject(new Error('Navigation with an absolute path prevented.'));
+    }
+
     if (!modalSettings?.keepPrevious) {
       const closed = await this.modalService.closeModalsWithDirtyCheck();
       if (!closed) return;
@@ -115,6 +125,11 @@ export class Navigation {
   };
 
   openAsDrawer = async (path: string, drawerSettings: DrawerSettings, onCloseCallback?: () => void) => {
+    if (path === '/') {
+      console.warn('Navigation with an absolute path prevented.');
+      return Promise.reject(new Error('Navigation with an absolute path prevented.'));
+    }
+
     const normalizedPath = path.replace(/\/\/+/g, '/');
     const redirectPath = await NavigationHelpers.validatePathAndGetRedirect(normalizedPath, this.luigi);
     if (!redirectPath) return;

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -963,9 +963,10 @@ export class NavigationService {
 
     const normalizedPath = computedPath.replace(/\/\/+/g, '/');
     const chosenHistoryMethod: HistoryMethod = !preventHistoryEntry ? 'pushState' : 'replaceState';
-    const currentPath = RoutingHelpers.getCurrentPath(this.luigi, hashRouting).path;
+    const { path: currentPath, query: currentQuery } = RoutingHelpers.getCurrentPath(this.luigi, hashRouting);
+    const currentFullPath = currentPath + (currentQuery ? '?' + currentQuery : '');
 
-    if (GenericHelpers.trimLeadingSlash(currentPath) === GenericHelpers.trimLeadingSlash(normalizedPath)) {
+    if (GenericHelpers.trimLeadingSlash(currentFullPath) === GenericHelpers.trimLeadingSlash(normalizedPath)) {
       return;
     }
 


### PR DESCRIPTION
Summary
Fix navigation guard for absolute root path (/) in modal and drawer: Adds the same check from the old core's _internalLinkManager.js to core-modular's navigate(), openAsModal(), and openAsDrawer() methods, preventing navigation with path / when modal or drawer settings are provided.

Fix same-path comparison ignoring node params: handleNavigationRequest previously compared only the path without query parameters, causing navigation to be skipped when navigating to the same path but with different node params (e.g. removing ~test=true). The comparison now includes the full path with query string, matching the old core's behavior in Routing.navigateTo().

Details
Absolute path guard
In the old core, _internalLinkManager.js rejects navigation to / when modalSettings, splitViewSettings, or drawerSettings are set. This check was missing in core-modular. It is now applied in:

Navigation.navigate() — guards against modalSettings and drawerSettings
Navigation.openAsModal() — guards against path === '/'
Navigation.openAsDrawer() — guards against path === '/'
Node params comparison fix
When calling Luigi.navigation().withParams({test: true}).navigate('/home/settings') followed by Luigi.navigation().navigate('/home/settings') (without params), the second navigation was silently skipped because the path comparison in handleNavigationRequest only looked at the path portion (stripped of query params via getCurrentPath), while buildPath appends node params to the computed path. The fix reconstructs the full current path including the query string before comparing.