### PR TITLE
Fix fiddle login flow

### DIFF
--- a/website/fiddle/public/auth/callback.html
+++ b/website/fiddle/public/auth/callback.html
@@ -25,12 +25,10 @@
       };
 
       const getHashParams = () => {
-        const hash = encodeURIComponent(window.location.hash.substring(1));
-        return decodeURIComponent(hash)
-          .split('&')
-          .reduce(function (result, item) {
-            var parts = item.split('=');
-            result[parts[0]] = parts[1];
+        return new URLSearchParams(window.location.hash.substring(1))
+          .entries()
+          .reduce(function (result, [key, value]) {
+            result[key] = value;
             return result;
           }, Object.create(null));
       };


### PR DESCRIPTION
## Summary
Fix atob crash (InvalidCharacterError) in the fiddle auth callback on the deployed version (fiddle.luigi-project.io)

## Problem
The getHashParams() function used a manual encodeURIComponent/decodeURIComponent roundtrip followed by a naive split('=') to parse the URL hash fragment. This caused two issues:

Double-encoded state parameter — On the deployed version, the state value arrives double-URL-encoded (e.g. %253D%253D instead of ==). The encode/decode roundtrip is a no-op, so only the single decodeURIComponent before atob() fires, leaving %3D in the string — which is not valid Base64.
Splitting on = — Base64 values and other parameters containing = (like id_token) were silently truncated.
The bug only appears in the deployed environment because locally the mock auth server does not URL-encode the fragment values.

## Fix
Replace the manual hash parsing with URLSearchParams, which correctly handles URL-decoding and key/value 
separation.
Closes #5232