### PR TITLE
Fix/nav item click link nodes

### DIFF
--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -451,6 +451,16 @@ export class NavigationService {
       return;
     }
 
+    if (node.link) {
+      const isAbsolute = node.link.startsWith('/');
+      if (isAbsolute) {
+        return this.luigi.navigation().navigate(node.link);
+      }
+      const parentPath = node.parent ? RoutingHelpers.getNodePath(node.parent) : '';
+      const resolvedPath = `${parentPath}/${node.link}`.replace(/\/\/+/g, '/');
+      return this.luigi.navigation().navigate(resolvedPath);
+    }
+
     let fullPath = RoutingHelpers.getNodePath(node);
     let pathParams = pathData?.pathParams;
 

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -546,6 +546,89 @@ describe('NavigationService', () => {
 
       expect(navigateSpy).not.toHaveBeenCalled();
     });
+
+    it('should navigate to absolute link path', async () => {
+      const navigateSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy
+      });
+
+      const node = {
+        link: '/home/settings',
+        label: 'Go to absolute path'
+      };
+
+      await navigationService.navItemClick(node as any);
+
+      expect(navigateSpy).toHaveBeenCalledWith('/home/settings');
+    });
+
+    it('should resolve relative link path against parent node', async () => {
+      const navigateSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy
+      });
+
+      const parentNode = {
+        pathSegment: 'pr1',
+        parent: { pathSegment: 'projects', parent: null }
+      };
+
+      const node = {
+        link: 'dps/dps1',
+        label: 'Go to relative path',
+        parent: parentNode
+      };
+
+      jest.spyOn(RoutingHelpers, 'getNodePath').mockReturnValue('/projects/pr1');
+
+      await navigationService.navItemClick(node as any);
+
+      expect(RoutingHelpers.getNodePath).toHaveBeenCalledWith(parentNode);
+      expect(navigateSpy).toHaveBeenCalledWith('/projects/pr1/dps/dps1');
+    });
+
+    it('should resolve relative link path without parent to root-relative', async () => {
+      const navigateSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy
+      });
+
+      const node = {
+        link: 'some/path',
+        label: 'Relative without parent',
+        parent: undefined
+      };
+
+      await navigationService.navItemClick(node as any);
+
+      expect(navigateSpy).toHaveBeenCalledWith('/some/path');
+    });
+
+    it('should resolve relative link path when parent has dynamic path parameters', async () => {
+      const navigateSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy
+      });
+
+      const parentNode = {
+        pathSegment: ':projectId',
+        parent: { pathSegment: 'projects', parent: null }
+      };
+
+      const node = {
+        link: 'settings/general',
+        label: 'Go to settings',
+        parent: parentNode
+      };
+
+      jest.spyOn(RoutingHelpers, 'getNodePath').mockReturnValue('/projects/:projectId');
+
+      await navigationService.navItemClick(node as any);
+
+      expect(RoutingHelpers.getNodePath).toHaveBeenCalledWith(parentNode);
+      expect(navigateSpy).toHaveBeenCalledWith('/projects/:projectId/settings/general');
+    });
   });
 
   describe('NavigationService.handleNavigationRequest', () => {

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -546,6 +546,64 @@ describe('NavigationService', () => {
 
       expect(navigateSpy).not.toHaveBeenCalled();
     });
+
+    it('should navigate to absolute link path', async () => {
+      const navigateSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy
+      });
+
+      const node = {
+        link: '/home/settings',
+        label: 'Go to absolute path'
+      };
+
+      await navigationService.navItemClick(node as any);
+
+      expect(navigateSpy).toHaveBeenCalledWith('/home/settings');
+    });
+
+    it('should resolve relative link path against parent node', async () => {
+      const navigateSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy
+      });
+
+      const parentNode = {
+        pathSegment: 'pr1',
+        parent: { pathSegment: 'projects', parent: null }
+      };
+
+      const node = {
+        link: 'dps/dps1',
+        label: 'Go to relative path',
+        parent: parentNode
+      };
+
+      jest.spyOn(RoutingHelpers, 'getNodePath').mockReturnValue('/projects/pr1');
+
+      await navigationService.navItemClick(node as any);
+
+      expect(RoutingHelpers.getNodePath).toHaveBeenCalledWith(parentNode);
+      expect(navigateSpy).toHaveBeenCalledWith('/projects/pr1/dps/dps1');
+    });
+
+    it('should resolve relative link path without parent to root-relative', async () => {
+      const navigateSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy
+      });
+
+      const node = {
+        link: 'some/path',
+        label: 'Relative without parent',
+        parent: undefined
+      };
+
+      await navigationService.navItemClick(node as any);
+
+      expect(navigateSpy).toHaveBeenCalledWith('/some/path');
+    });
   });
 
   describe('NavigationService.handleNavigationRequest', () => {


### PR DESCRIPTION
## Summary
Fixes navigation for nodes that use the link property instead of pathSegment
Clicking such nodes in the side navigation previously did nothing because getNodePath(node) requires pathSegment
Absolute links (e.g. /home/settings) now navigate directly
Relative links (e.g. dps/dps1) are resolved against the parent node's path

## Problem
Navigation nodes can be configured with a link property to redirect to another path:


{
  link: '/home/settings',
  label: 'Go to absolute path',
  icon: 'switch-views'
}
The getRouteLink() helper in routing-helpers.ts already handles node.link correctly for building `<a href>` attributes. However, navItemClick() — which handles the actual click event — only called getNodePath(node), which traverses pathSegment up the node tree. For link-nodes (which have no pathSegment), this produced an empty or undefined path, causing silent navigation failure.

## Fix
Added a check for node.link in navItemClick() before falling through to getNodePath():

Absolute links (/home/settings): navigate directly
Relative links (dps/dps1): resolve against the parent node's path via getNodePath(node.parent)