### PR TITLE
Fix/open node in modal side nav

### DIFF
--- a/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
+++ b/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
@@ -339,7 +339,7 @@ function renderNodeOrCategory(item, leftNavData) {
       el.setAttribute('target', item.externalLink.sameWindow ? '_self' : '_blank');
     } else {
       el.setAttribute('luigi-route', leftNavData.basePath + '/' + item.node.pathSegment);
-      if (item.href) el.setAttribute('href', item.href);
+      if (item.href && !item.node?.openNodeInModal) el.setAttribute('href', item.href);
     }
     el._luigiItem = item;
     if (item.selected) el.setAttribute('selected', '');
@@ -366,7 +366,7 @@ function renderNodeOrCategory(item, leftNavData) {
           sub.setAttribute('target', nodeWrapper.externalLink.sameWindow ? '_self' : '_blank');
         } else {
           sub.setAttribute('luigi-route', leftNavData.basePath + '/' + nodeWrapper.node.pathSegment);
-          if (nodeWrapper.href) sub.setAttribute('href', nodeWrapper.href);
+          if (nodeWrapper.href && !nodeWrapper.node?.openNodeInModal) sub.setAttribute('href', nodeWrapper.href);
         }
         if (nodeWrapper.selected) sub.setAttribute('selected', '');
         el.appendChild(sub);

--- a/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
+++ b/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
@@ -339,7 +339,7 @@ function renderNodeOrCategory(item, leftNavData) {
       el.setAttribute('target', item.externalLink.sameWindow ? '_self' : '_blank');
     } else {
       el.setAttribute('luigi-route', leftNavData.basePath + '/' + item.node.pathSegment);
-      if (item.href && !item.node?.openNodeInModal) el.setAttribute('href', item.href);
+      if (item.href) el.setAttribute('href', item.href);
     }
     el._luigiItem = item;
     if (item.selected) el.setAttribute('selected', '');
@@ -366,7 +366,7 @@ function renderNodeOrCategory(item, leftNavData) {
           sub.setAttribute('target', nodeWrapper.externalLink.sameWindow ? '_self' : '_blank');
         } else {
           sub.setAttribute('luigi-route', leftNavData.basePath + '/' + nodeWrapper.node.pathSegment);
-          if (nodeWrapper.href && !nodeWrapper.node?.openNodeInModal) sub.setAttribute('href', nodeWrapper.href);
+          if (nodeWrapper.href) sub.setAttribute('href', nodeWrapper.href);
         }
         if (nodeWrapper.selected) sub.setAttribute('selected', '');
         el.appendChild(sub);
@@ -922,6 +922,13 @@ const connector = {
             // navigation was cancelled (e.g. unsaved changes dismissed)
           }
         });
+        // Prevent native anchor navigation when href is set (same as core's handleNavAnchorClickedWithoutMetaKey).
+        // Meta+click still opens in a new tab. Only intercept real user clicks, not synthetic ones from fireDecoratorEvent.
+        sidenav.addEventListener('click', (event) => {
+          if (event.isTrusted && !(event.ctrlKey || event.metaKey || event.shiftKey)) {
+            event.preventDefault();
+          }
+        }, true);
       }
       sidenav.innerHTML = '';
       if (leftNavData?.selectedNode?.hideSideNav) {

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -273,9 +273,7 @@ export class NavigationService {
         catNode.category?.nodes?.push({
           altText: node.altText,
           externalLink: node.externalLink,
-          href: node.openNodeInModal
-            ? undefined
-            : node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi),
+          href: node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi),
           icon: node.icon,
           label: node.label ? this.luigi.i18n().getTranslation(node.label) : undefined,
           node,
@@ -287,9 +285,7 @@ export class NavigationService {
           altText: node.altText,
           badgeCounter: node.badgeCounter,
           externalLink: node.externalLink,
-          href: node.openNodeInModal
-            ? undefined
-            : node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi),
+          href: node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi),
           icon: node.icon,
           label: node.label ? this.luigi.i18n().getTranslation(node.label) : undefined,
           node,

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -248,7 +248,7 @@ export class NavigationService {
           altText: node.altText,
           icon: node.icon,
           externalLink: node.externalLink,
-          href: node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi)
+          href: node.openNodeInModal ? undefined : (node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi))
         });
       } else {
         items.push({
@@ -259,7 +259,7 @@ export class NavigationService {
           node,
           selected: node === selectedNode,
           externalLink: node.externalLink,
-          href: node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi)
+          href: node.openNodeInModal ? undefined : (node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi))
         });
       }
     });
@@ -445,6 +445,17 @@ export class NavigationService {
   }
 
   async navItemClick(node: Node, pathData?: PathData): Promise<void> {
+    if (node.openNodeInModal) {
+      const fullPath = GenericHelpers.replaceVars(
+        RoutingHelpers.getNodePath(node),
+        pathData?.pathParams || {},
+        ':',
+        false
+      );
+      this.luigi.navigation().openAsModal(fullPath, node.openNodeInModal === true ? {} : node.openNodeInModal);
+      return;
+    }
+
     const dirtyStatusService = serviceRegistry.get(DirtyStatusService);
     await dirtyStatusService.getUnsavedChangesModalPromise();
 
@@ -473,6 +484,7 @@ export class NavigationService {
       );
       return;
     }
+
     return this.luigi.navigation().navigate(fullPath);
   }
 

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -248,7 +248,9 @@ export class NavigationService {
           altText: node.altText,
           icon: node.icon,
           externalLink: node.externalLink,
-          href: node.openNodeInModal ? undefined : (node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi))
+          href: node.openNodeInModal
+            ? undefined
+            : node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi)
         });
       } else {
         items.push({
@@ -259,7 +261,9 @@ export class NavigationService {
           node,
           selected: node === selectedNode,
           externalLink: node.externalLink,
-          href: node.openNodeInModal ? undefined : (node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi))
+          href: node.openNodeInModal
+            ? undefined
+            : node.externalLink?.url || RoutingHelpers.getNodeHref(node, pathData.pathParams, this.luigi)
         });
       }
     });

--- a/core-modular/src/types/navigation.ts
+++ b/core-modular/src/types/navigation.ts
@@ -161,7 +161,7 @@ export interface Node {
   };
   navigationContext?: string;
   onNodeActivation?: (node: Node) => boolean | void;
-  openNodeInModal?: boolean;
+  openNodeInModal?: boolean | ModalSettings;
   pageErrorHandler?: PageErrorHandler;
   parent?: Node;
   pathSegment?: string;

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -1073,7 +1073,12 @@ describe('NavigationService', () => {
     });
 
     it('should not include href when node has openNodeInModal set to an object', () => {
-      const node1: Node = { pathSegment: 'settings', label: 'Settings', openNodeInModal: { size: 'm' }, children: [] } as any;
+      const node1: Node = {
+        pathSegment: 'settings',
+        label: 'Settings',
+        openNodeInModal: { size: 'm' },
+        children: []
+      } as any;
       jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
       luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
       const pathData: PathData = {

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -1086,7 +1086,7 @@ describe('NavigationService', () => {
       jest.restoreAllMocks();
     });
 
-    it('should include href on openNodeInModal nodes (same as core, navigation is prevented at UI layer)', () => {
+    it('should include href on openNodeInModal nodes (same as core, navigation is prevented at UI layer)', async () => {
       const node1: Node = { pathSegment: 'settings', label: 'Settings', openNodeInModal: true, children: [] };
       jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
       luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
@@ -1098,8 +1098,8 @@ describe('NavigationService', () => {
         pathParams: {},
         matchedPath: ''
       };
-      const items = navigationService.buildNavItems([node1], undefined, pathData);
-      expect(items[0].href).toBe('#/settings');
+      const data = await navigationService.buildNavItems([node1], undefined, pathData);
+      expect(data.items[0].href).toBe('#/settings');
       jest.restoreAllMocks();
     });
   });

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -629,6 +629,98 @@ describe('NavigationService', () => {
       expect(RoutingHelpers.getNodePath).toHaveBeenCalledWith(parentNode);
       expect(navigateSpy).toHaveBeenCalledWith('/projects/:projectId/settings/general');
     });
+
+    it('should open modal instead of navigating when openNodeInModal is true', async () => {
+      const navigateSpy = jest.fn();
+      const openAsModalSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy,
+        openAsModal: openAsModalSpy
+      });
+
+      jest.spyOn(RoutingHelpers, 'getNodePath').mockReturnValue('/projects/pr1/settings');
+      jest.spyOn(GenericHelpers, 'replaceVars').mockReturnValue('/projects/pr1/settings');
+
+      const node = {
+        pathSegment: 'settings',
+        label: 'Settings',
+        openNodeInModal: true,
+        children: []
+      };
+
+      const pathData: PathData = {
+        pathParams: {},
+        rootNodes: []
+      };
+
+      await navigationService.navItemClick(node, pathData);
+
+      expect(openAsModalSpy).toHaveBeenCalledWith('/projects/pr1/settings', {});
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should pass modal settings to openAsModal when openNodeInModal is an object', async () => {
+      const navigateSpy = jest.fn();
+      const openAsModalSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: navigateSpy,
+        openAsModal: openAsModalSpy
+      });
+
+      jest.spyOn(RoutingHelpers, 'getNodePath').mockReturnValue('/projects/pr1/settings');
+      jest.spyOn(GenericHelpers, 'replaceVars').mockReturnValue('/projects/pr1/settings');
+
+      const modalSettings = { size: 'm', title: 'Settings' };
+      const node = {
+        pathSegment: 'settings',
+        label: 'Settings',
+        openNodeInModal: modalSettings,
+        children: []
+      };
+
+      const pathData: PathData = {
+        pathParams: {},
+        rootNodes: []
+      };
+
+      await navigationService.navItemClick(node, pathData);
+
+      expect(openAsModalSpy).toHaveBeenCalledWith('/projects/pr1/settings', modalSettings);
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should replace path params when opening modal', async () => {
+      const openAsModalSpy = jest.fn();
+      luigiMock.navigation = jest.fn().mockReturnValue({
+        navigate: jest.fn(),
+        openAsModal: openAsModalSpy
+      });
+
+      jest.spyOn(RoutingHelpers, 'getNodePath').mockReturnValue('/projects/:projectId/settings');
+      jest.spyOn(GenericHelpers, 'replaceVars').mockReturnValue('/projects/pr1/settings');
+
+      const node = {
+        pathSegment: 'settings',
+        label: 'Settings',
+        openNodeInModal: true,
+        children: []
+      };
+
+      const pathData: PathData = {
+        pathParams: { projectId: 'pr1' },
+        rootNodes: []
+      };
+
+      await navigationService.navItemClick(node, pathData);
+
+      expect(GenericHelpers.replaceVars).toHaveBeenCalledWith(
+        '/projects/:projectId/settings',
+        { projectId: 'pr1' },
+        ':',
+        false
+      );
+      expect(openAsModalSpy).toHaveBeenCalledWith('/projects/pr1/settings', {});
+    });
   });
 
   describe('NavigationService.handleNavigationRequest', () => {
@@ -959,6 +1051,59 @@ describe('NavigationService', () => {
       };
       const items = navigationService.buildNavItems([node1], undefined, pathData);
       expect(items[0].category?.nodes?.[0].href).toBe('/node1');
+      jest.restoreAllMocks();
+    });
+
+    it('should not include href when node has openNodeInModal set to true', () => {
+      const node1: Node = { pathSegment: 'settings', label: 'Settings', openNodeInModal: true, children: [] };
+      jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
+      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
+      const pathData: PathData = {
+        selectedNode: undefined,
+        selectedNodeChildren: [node1],
+        nodesInPath: [],
+        rootNodes: [node1],
+        pathParams: {},
+        matchedPath: ''
+      };
+      const items = navigationService.buildNavItems([node1], undefined, pathData);
+      expect(items[0].href).toBeUndefined();
+      expect(RoutingHelpers.getNodeHref).not.toHaveBeenCalled();
+      jest.restoreAllMocks();
+    });
+
+    it('should not include href when node has openNodeInModal set to an object', () => {
+      const node1: Node = { pathSegment: 'settings', label: 'Settings', openNodeInModal: { size: 'm' }, children: [] } as any;
+      jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
+      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
+      const pathData: PathData = {
+        selectedNode: undefined,
+        selectedNodeChildren: [node1],
+        nodesInPath: [],
+        rootNodes: [node1],
+        pathParams: {},
+        matchedPath: ''
+      };
+      const items = navigationService.buildNavItems([node1], undefined, pathData);
+      expect(items[0].href).toBeUndefined();
+      jest.restoreAllMocks();
+    });
+
+    it('should not include href on category node when openNodeInModal is true', () => {
+      const category = { id: 'cat1', label: 'Category 1' };
+      const node1: Node = { pathSegment: 'settings', label: 'Settings', category, openNodeInModal: true, children: [] };
+      jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
+      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
+      const pathData: PathData = {
+        selectedNode: undefined,
+        selectedNodeChildren: [node1],
+        nodesInPath: [],
+        rootNodes: [node1],
+        pathParams: {},
+        matchedPath: ''
+      };
+      const items = navigationService.buildNavItems([node1], undefined, pathData);
+      expect(items[0].category?.nodes?.[0].href).toBeUndefined();
       jest.restoreAllMocks();
     });
   });

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -1086,7 +1086,7 @@ describe('NavigationService', () => {
       jest.restoreAllMocks();
     });
 
-    it('should not include href when node has openNodeInModal set to true', () => {
+    it('should include href on openNodeInModal nodes (same as core, navigation is prevented at UI layer)', () => {
       const node1: Node = { pathSegment: 'settings', label: 'Settings', openNodeInModal: true, children: [] };
       jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
       luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
@@ -1099,48 +1099,7 @@ describe('NavigationService', () => {
         matchedPath: ''
       };
       const items = navigationService.buildNavItems([node1], undefined, pathData);
-      expect(items[0].href).toBeUndefined();
-      expect(RoutingHelpers.getNodeHref).not.toHaveBeenCalled();
-      jest.restoreAllMocks();
-    });
-
-    it('should not include href when node has openNodeInModal set to an object', () => {
-      const node1: Node = {
-        pathSegment: 'settings',
-        label: 'Settings',
-        openNodeInModal: { size: 'm' },
-        children: []
-      } as any;
-      jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
-      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
-      const pathData: PathData = {
-        selectedNode: undefined,
-        selectedNodeChildren: [node1],
-        nodesInPath: [],
-        rootNodes: [node1],
-        pathParams: {},
-        matchedPath: ''
-      };
-      const items = navigationService.buildNavItems([node1], undefined, pathData);
-      expect(items[0].href).toBeUndefined();
-      jest.restoreAllMocks();
-    });
-
-    it('should not include href on category node when openNodeInModal is true', () => {
-      const category = { id: 'cat1', label: 'Category 1' };
-      const node1: Node = { pathSegment: 'settings', label: 'Settings', category, openNodeInModal: true, children: [] };
-      jest.spyOn(RoutingHelpers, 'getNodeHref').mockReturnValue('#/settings');
-      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
-      const pathData: PathData = {
-        selectedNode: undefined,
-        selectedNodeChildren: [node1],
-        nodesInPath: [],
-        rootNodes: [node1],
-        pathParams: {},
-        matchedPath: ''
-      };
-      const items = navigationService.buildNavItems([node1], undefined, pathData);
-      expect(items[0].category?.nodes?.[0].href).toBeUndefined();
+      expect(items[0].href).toBe('#/settings');
       jest.restoreAllMocks();
     });
   });


### PR DESCRIPTION
## fix: prevent navigation when `openNodeInModal` is set on a node

### Summary
- Nodes with `openNodeInModal` now correctly open their `viewUrl` in a modal without navigating the main content area
- Same approach as core: `href` is set for accessibility/Ctrl+click, but `preventDefault()` on the click event stops native anchor navigation

### Problem
Clicking a navigation node with `openNodeInModal: true` would:
1. Open the modal correctly (via `navItemClick`)
2. **Also** navigate the main content area to that node's path

The root cause was that the UI5 SideNavigation component renders an internal `<a href="...">` tag in its shadow DOM. On click, the browser's native link navigation fires before any `selection-change` event, changing `location.hash` and triggering `handleRouteChange` via the `hashchange` listener.

### Changes
- **`navigation.service.ts`** (`navItemClick`): Open modal and return early when `openNodeInModal` is set (supports both `true` and `ModalSettings` object)
- **`navigation.ts`**: Extend `openNodeInModal` type to `boolean | ModalSettings`
- **`lui-ui5wc.js`** (simple-app + template): Add capture-phase click listener that calls `event.preventDefault()` on trusted user clicks without meta keys — same pattern as core's `handleNavAnchorClickedWithoutMetaKey`. This prevents the shadow DOM anchor from navigating while keeping `href` intact for accessibility and Ctrl/Cmd+click (open in new tab).
- **`navigation.service.spec.ts`**: Unit tests for `navItemClick` with `openNodeInModal`

### Differences from previous approach
- `href` is **not** suppressed in `buildNavItems` — it remains set on all nodes (same as core)
- Navigation is prevented at the UI layer via `preventDefault()`, not at the data layer

### Test plan
- [x] Navigate to a node with `openNodeInModal: true` → modal opens, URL does not change
- [x] Navigate to a node with `openNodeInModal: { size: 'm' }` → modal opens with correct size
- [x] Ctrl/Cmd+click on any nav item → opens href in new tab
- [x] Close modal → previous content still visible
- [x] Normal navigation nodes still work as before
- [x] Unit tests pass
