### PR TITLE
goback for modals

### DIFF
--- a/core-modular/src/core-api/navigation.ts
+++ b/core-modular/src/core-api/navigation.ts
@@ -97,7 +97,7 @@ export class Navigation {
     this.navigate(newPath);
   };
 
-  openAsModal = async (path: string, modalSettings: ModalSettings, onCloseCallback?: () => void) => {
+  openAsModal = async (path: string, modalSettings: ModalSettings, onCloseCallback?: (goBackValue?: any) => void) => {
     if (path === '/') {
       console.warn('Navigation with an absolute path prevented.');
       return Promise.reject(new Error('Navigation with an absolute path prevented.'));

--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -369,7 +369,33 @@ export const UIModule = {
           }
         };
 
+        // TODO: goBackContext forwarding is basic — preserveView is not yet fully implemented in core-modular
+        const onGoBackRequestHandler = async (event: any) => {
+          try {
+            await dirtyStatusService.getUnsavedChangesModalPromise(lc);
+          } catch (e) {
+            return;
+          }
+          const goBackContext = event?.detail || event?.payload;
+          resolveFn && resolveFn();
+          if (luigi.getConfigValue('routing.showModalPathInUrl') && modalService.getModalStackLength() === 0) {
+            routingService.removeModalDataFromUrl(true);
+          }
+          if (goBackContext && Object.keys(goBackContext).length) {
+            const containerWrapper = luigi.getEngine()._connector?.getContainerWrapper();
+            if (containerWrapper) {
+              const activeContainer = [...containerWrapper.childNodes].find(
+                (el: any) => el.tagName?.indexOf('LUIGI-') === 0 && el.style?.display !== 'none'
+              ) as any;
+              if (activeContainer?.updateContext) {
+                activeContainer.updateContext({ goBackContext }, { withoutSync: false });
+              }
+            }
+          }
+        };
+
         lc.addEventListener(Events.CLOSE_CURRENT_MODAL_REQUEST, onCloseRequestHandler);
+        lc.addEventListener(Events.GO_BACK_REQUEST, onGoBackRequestHandler);
       });
     };
 

--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -337,7 +337,7 @@ export const UIModule = {
       }
     }
   },
-  openModal: async (luigi: Luigi, node: Node, modalSettings: ModalSettings, onCloseCallback?: () => void) => {
+  openModal: async (luigi: Luigi, node: Node, modalSettings: ModalSettings, onCloseCallback?: (goBackValue?: any) => void) => {
     const lc = await createContainer(node, luigi);
     UIModule.modalContainer.push(lc);
     const routingService = serviceRegistry.get(RoutingService);
@@ -369,7 +369,6 @@ export const UIModule = {
           }
         };
 
-        // TODO: goBackContext forwarding is basic — preserveView is not yet fully implemented in core-modular
         const onGoBackRequestHandler = async (event: any) => {
           try {
             await dirtyStatusService.getUnsavedChangesModalPromise(lc);
@@ -377,6 +376,7 @@ export const UIModule = {
             return;
           }
           const goBackContext = event?.detail || event?.payload;
+          onCloseCallback?.(goBackContext);
           resolveFn && resolveFn();
           if (luigi.getConfigValue('routing.showModalPathInUrl') && modalService.getModalStackLength() === 0) {
             routingService.removeModalDataFromUrl(true);


### PR DESCRIPTION
## Fix: linkManager().goBack() from modal context does not close the modal

Closes #5305

### Summary

- Add `GO_BACK_REQUEST` event listener to modal containers so that calling `LuigiClient.linkManager().goBack()` from within a modal microfrontend correctly closes the modal
- Respect dirty state checks before closing (consistent with `closeCurrentModal()` behavior)
- Forward `goBackContext` to the active main container after modal dismissal

### Root Cause

When a microfrontend inside a modal calls `goBack()`, the container dispatches a `go-back-request` custom event on the `luigi-container` element. However, `openModal()` in `ui-module.ts` only registered a listener for `close-current-modal-request` — the `go-back-request` event was unhandled, leaving the modal open.

### Changes

- `core-modular/src/modules/ui-module.ts`: Added `onGoBackRequestHandler` that listens for `GO_BACK_REQUEST` on the modal's `luigi-container`, performs the unsaved-changes check, closes the modal, cleans up the URL, and forwards the `goBackContext` to the underlying view.

### Test Plan

- [x] Open a microfrontend as modal (`openAsModal`)
- [x] Call `LuigiClient.linkManager().goBack()` inside the modal MFE
- [x] Verify the modal closes
- [x] Verify `goBackContext` data is received by the parent view
- [x] Verify dirty state prompt appears if unsaved changes exist
- [x] Verify `closeCurrentModal()` still works as before

### Limitations

`goBackContext` forwarding is basic — `preserveView` is not yet fully implemented in core-modular, so the full preserved-view stack navigation (as in the legacy core) is not covered by this fix.
