### PR TITLE
fix: sanitize child_process call in bootstrap.js...

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2,7 +2,7 @@
  * This file is used to run (npm install) in all of the folders which have it as a prerequisite in the pipeline and during local development
  */
 
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 
 // Array of folder names
 const folders = [
@@ -29,9 +29,7 @@ let isVerbose = verboseFlagIndex !== -1;
 // Function to install npm packages in given folder
 function installPackages(folder, index, totalFolders) {
   return new Promise((resolve, reject) => {
-    const command = `cd ${folder} && npm install`;
-
-    exec(command, (error, stdout, stderr) => {
+    execFile('npm', ['install'], { cwd: folder }, (error, stdout, stderr) => {
       if (error) {
         console.error(`\x1b[31mError installing npm packages in ${folder} \x1b[0m`);
         reject(error);


### PR DESCRIPTION
## Summary
Code hygiene improvement to \`bootstrap.js\`: replace \`exec()\` with \`execFile()\`.

## Background
Semgrep rule \`javascript.lang.security.detect-child-process.detect-child-process\` flagged this as a potential command injection. After manual review, this is a **false positive**:

- \`folder\` comes only from the hardcoded literal array at lines 8–24 of \`bootstrap.js\`; no external input flows into the call.
- \`bootstrap.js\` is a dev/CI helper script at the repo root, not included in any published npm package.
- Semgrep fired because \`folder\` is a function parameter — the rule cannot see across the call site that the caller always passes a hardcoded string from the same file. This is the classic false-positive shape for this taint rule (it labels itself "needs manual review" for exactly this reason).

The change from `` exec(`cd ${folder} && npm install`) `` to \`execFile('npm', ['install'], { cwd: folder })\` is accepted as a **code hygiene improvement** — avoiding shell string interpolation even for trusted input.

## Changes
- \`bootstrap.js\`: use \`execFile\` with \`cwd\` option instead of \`exec\` with a shell string

## Verification
- [x] Build passes
- [x] \`npm run bootstrap\` works correctly with the new implementation