### PR TITLE
Feature/confirmation modal button confirm false

### DIFF
--- a/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
+++ b/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
@@ -1169,19 +1169,25 @@ const connector = {
 
     const ui5Toolbar = document.createElement('ui5-toolbar');
     ui5Toolbar.setAttribute('slot', 'footer');
-    const ui5ToolBarBtnConfirm = document.createElement('ui5-toolbar-button');
-    settings.buttonConfirm && ui5ToolBarBtnConfirm.setAttribute('text', settings.buttonConfirm);
-    ui5ToolBarBtnConfirm.addEventListener('click', () => {
-      handler.confirm();
-      document.body.removeChild(dialog);
-    });
+    if (settings.buttonConfirm !== false) {
+      const ui5ToolBarBtnConfirm = document.createElement('ui5-toolbar-button');
+      settings.buttonConfirm && ui5ToolBarBtnConfirm.setAttribute('text', settings.buttonConfirm);
+      ui5ToolBarBtnConfirm.setAttribute('design', 'Emphasized');
+      ui5ToolBarBtnConfirm.addEventListener('click', () => {
+        handler.confirm();
+        document.body.removeChild(dialog);
+      });
+      ui5Toolbar.appendChild(ui5ToolBarBtnConfirm);
+    }
     const ui5ToolBarBtnDismiss = document.createElement('ui5-toolbar-button');
     settings.buttonDismiss && ui5ToolBarBtnDismiss.setAttribute('text', settings.buttonDismiss);
+    if (settings.buttonConfirm === false) {
+      ui5ToolBarBtnDismiss.setAttribute('design', 'Emphasized');
+    }
     ui5ToolBarBtnDismiss.addEventListener('click', () => {
       handler.dismiss();
       document.body.removeChild(dialog);
     });
-    ui5Toolbar.appendChild(ui5ToolBarBtnConfirm);
     ui5Toolbar.appendChild(ui5ToolBarBtnDismiss);
     dialog.appendChild(ui5Toolbar);
     document.body.appendChild(dialog);

--- a/core-modular/src/core-api/ux.ts
+++ b/core-modular/src/core-api/ux.ts
@@ -108,7 +108,9 @@ export class UX {
           header: this.luigi.i18n().getTranslation(settings.header || 'luigi.confirmationModal.header'),
           body: this.luigi.i18n().getTranslation(settings.body || 'luigi.confirmationModal.body'),
           buttonDismiss: this.luigi.i18n().getTranslation(settings.buttonDismiss || 'luigi.button.dismiss'),
-          buttonConfirm: this.luigi.i18n().getTranslation(settings.buttonConfirm || 'luigi.button.confirm')
+          buttonConfirm: settings.buttonConfirm === false
+            ? false
+            : this.luigi.i18n().getTranslation(settings.buttonConfirm || 'luigi.button.confirm')
         }
       };
     }

--- a/core-modular/src/modules/ux-module.ts
+++ b/core-modular/src/modules/ux-module.ts
@@ -89,9 +89,11 @@ export const UXModule = {
           buttonDismiss: UXModule.luigi
             .i18n()
             .getTranslation(confirmationModalSettings.buttonDismiss || 'luigi.button.dismiss'),
-          buttonConfirm: UXModule.luigi
-            .i18n()
-            .getTranslation(confirmationModalSettings.buttonConfirm || 'luigi.button.confirm')
+          buttonConfirm: confirmationModalSettings.buttonConfirm === false
+            ? false
+            : UXModule.luigi
+                .i18n()
+                .getTranslation(confirmationModalSettings.buttonConfirm || 'luigi.button.confirm')
         }
       };
     }

--- a/core-modular/src/types/ux.ts
+++ b/core-modular/src/types/ux.ts
@@ -34,7 +34,7 @@ export interface ConfirmationModalSettings {
   type?: string;
   header?: string;
   body?: string;
-  buttonConfirm?: string;
+  buttonConfirm?: string | false;
   buttonDismiss?: string;
 }
 


### PR DESCRIPTION
### Summary
Adds the ability to hide the confirm button in the ConfirmationModal by setting `buttonConfirm: false` in the settings — matching the existing behavior in the core.
Extends the ConfirmationModalSettings.buttonConfirm type from string to `string | false`.
Fixes the translation logic in core-api/ux.ts and ux-module.ts to preserve the false value instead of overriding it with the default translation key.
